### PR TITLE
Add che flavor functionality

### DIFF
--- a/deploy/crds/che.eclipse.org_kubernetesimagepullers_crd.yaml
+++ b/deploy/crds/che.eclipse.org_kubernetesimagepullers_crd.yaml
@@ -42,6 +42,8 @@ spec:
               type: string
             cachingMemoryRequest:
               type: string
+            cheFlavor:
+              type: string
             configMapName:
               type: string
             daemonsetName:

--- a/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
+++ b/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
@@ -20,6 +20,7 @@ type KubernetesImagePullerSpec struct {
 	CachingCpuRequest    string `json:"cachingCPURequest,omitempty"`
 	CachingCpuLimit      string `json:"cachingCPULimit,omitempty"`
 	NodeSelector         string `json:"nodeSelector,omitempty"`
+	CheFlavor            string `json:"cheFlavor,omitempty"`
 }
 
 // KubernetesImagePullerStatus defines the observed state of KubernetesImagePuller


### PR DESCRIPTION
Adds a field to the `KubernetesImagePuller` spec, `cheFlavor`.  If `cheFlavor` is not set, it is set to `che`, the default mode, which will run `quay.io/eclipse/kubernetes-image-puller` for deployments.  If `cheFlavor` is set to `codeready` it will use `registry.redhat.io/codeready-workspaces/imagepuller-rhel8` for deployments.

Part of https://github.com/eclipse/che/issues/18569

Signed-off-by: Tom George <tgeorge@redhat.com>