### PR TITLE
fix: Update deployment when imagePullerImage changed from CR spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,27 @@ https://github.com/operator-framework/community-operators/pull/1661
 
 https://github.com/operator-framework/community-operators/pull/1662
 
-### Building
+### Development
+
+#### Prequisites
+* Go >=`1.15`
+* Operator SDK `v0.19.4` (recommended)
+
+#### Building
 
 `operator-sdk build quay.io/eclipse/kubernetes-image-puller-operator:tag`
 
-### Testing
+#### Testing
 
 `go test -v ./pkg... ./cmd...`
 
-### Releasing a new version of the operator to OperatorHub
+#### Releasing a new version of the operator to OperatorHub
 
 A quirk of this project is that while the repository is named `kubernetes-image-puller-operator`, the operator bundle on OperatorHub is named `kubernetes-imagepuller-operator`.  This was caused by the previous version of OLM deployment that required a Quay.io Application.  
 
 1. Change the version in `version/version.go` to match your new operator bundle version.  If your new bundle is v0.5.1, for example, this is what the `Version` var should be in `version/version.go`.
 2. Make a directory in `deploy/olm-catalog/kubernetes-imagepuller-operator/VERSION`
-3. Run `operator-sdk generate k8s` and `operator-sdk generate crds`
+3. Run `operator-sdk generate k8s` and `operator-sdk generate crds --crd-version=v1`
 4. Copy a previous version of `kubernetes-imagepuller-operator.vX.X.X.clusterserviceversion.yaml` to the new folder you made in step 2
 5. Edit the new `kubernetes-imagepuller-operator.vX.X.X.clusterserviceversion.yaml` and change the following fields:
   - `name` -  replace the verison tag to the new version

--- a/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
+++ b/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
@@ -27,6 +27,7 @@ type KubernetesImagePullerSpec struct {
 
 // KubernetesImagePullerStatus defines the observed state of KubernetesImagePuller
 type KubernetesImagePullerStatus struct {
+	ImagePullerImage string `json:"imagePullerImage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Fixes https://github.com/eclipse/che/issues/20317
Image: `quay.io/dkwon17/kubernetes-image-puller-operator:che-20317`

To test this PR:
1. Replace the image from this [line](https://github.com/che-incubator/kubernetes-image-puller-operator/blob/ab51525fa009a9e8876b214db6ad6be55ee68c8b/deploy/operator.yaml#L19) with `quay.io/dkwon17/kubernetes-image-puller-operator:che-20317`.
2. Deploy the KIP operator:
```
oc new-project k8s-image-puller

# generate the crd
operator-sdk generate k8s && operator-sdk generate crds

# apply
kubectl apply -f deploy/ --validate=false
kubectl apply -f deploy/crds/
```
3. Create new KubernetesImagePuller CR instance in the `k8s-image-puller` namespace:
![image](https://user-images.githubusercontent.com/83611742/130815986-e3aa6211-d3b3-4dd3-a817-714a9238bb89.png)

3. After creating the instance, change the `imagePullerImage` from the CR yaml definition. In the screenshot, the `spec.imagePullerImage` image tag was changed from `next` to `45210db`
![image](https://user-images.githubusercontent.com/83611742/130869409-92d36215-c40c-464d-9103-dc83d919c279.png)

4. After saving changes from step 3, reload the CR yaml definition, and the status should be updated with the new `imagePullerImage`
![image](https://user-images.githubusercontent.com/83611742/130869564-f58f1943-c6b9-44d1-b3c1-9b81699510c4.png)

5. View the pods. The KIP pod should use the new updated image:
![image](https://user-images.githubusercontent.com/83611742/130869643-8c65aa40-9210-48de-a404-8c2ecb98e627.png)


Signed-off-by: David Kwon <dakwon@redhat.com>