### PR TITLE
fix: removing the 'latest' tag from the release GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         context: .
         file: ./build/Dockerfile
-        tags:  quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }},quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.short_sha1 }},quay.io/eclipse/${{ steps.prep.outputs.image }}:latest
+        tags:  quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }},quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.short_sha1 }}
         push: true
     - 
       name: Send MM message


### PR DESCRIPTION
If I understand correctly it is planned not to push the `latest` tag at all during the release - https://quay.io/repository/eclipse/kubernetes-image-puller-operator?tab=tags&tag=latest