### PR TITLE
fix: Remove redundant sa from the bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cd config/manager && $(KUSTOMIZE) edit set image quay.io/eclipse/kubernetes-image-puller-operator:next=$(IMG)
 	cd ../..
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --package kubernetes-imagepuller-operator --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+
+	# SA already specified in a CSV, so remove a redundant one
+	rm bundle/manifests/kubernetes-image-puller-operator_v1_serviceaccount.yaml
+
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build
@@ -247,7 +251,6 @@ release-bundle:
 	cp -rf "$${crdNext}" "$${crdRelease}"
 	cp -rf \
 	"$${manifestPath}/controller-manager-metrics-service_v1_service.yaml" \
-	"$${manifestPath}/kubernetes-image-puller-operator_v1_serviceaccount.yaml" \
 	"$${manifestPath}/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml" \
 	"$${packageVersionPath}/"
 

--- a/bundle/manifests/kubernetes-image-puller-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/kubernetes-image-puller-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: kubernetes-image-puller-operator

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.0/kubernetes-image-puller-operator_v1_serviceaccount.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.0/kubernetes-image-puller-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: kubernetes-image-puller-operator


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

Removes SA from a bundle since it is already specified in the csv [1].
Duplication leads to failed tests in a PR for the community operator repository.

[1]  https://github.com/che-incubator/kubernetes-image-puller-operator/blob/ade33bad35307c4fb13dee5af3c336b4406d59a6/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml#L75