### PR TITLE
chore: update memory limit

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -133,7 +133,7 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 128Mi
+                    memory: 256Mi
                   requests:
                     cpu: 100m
                     memory: 64Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 100m
             memory: 64Mi


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

This PR increases the memory limit to match the memory limit for the che-operator deployment: https://github.com/eclipse-che/che-operator/blob/3830ac4e28983dbe928d0777f63c87bed43feb4b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml#L132

After discussing with @ibuziuk , we plan to do a KIPO 1.0.1 release with this change.

Fixes: https://github.com/eclipse/che/issues/21448