### PR TITLE
fix: update 1.0.1 CSV deployment image

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubernetes-image-puller-operator
-                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.0
+                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.1/kubernetes-imagepuller-operator.v1.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.1/kubernetes-imagepuller-operator.v1.0.1.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubernetes-image-puller-operator
-                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.0
+                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

I'm not sure how this happened but the image version in the deployment in the CSV wasn't updated in my previous PR: https://github.com/che-incubator/kubernetes-image-puller-operator/pull/80
