### PR TITLE
fix: update deployment image from make release-bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ release-bundle:
 	sed -i -e "s/\(name: kubernetes-imagepuller-operator.v\).*/\1$${version}/" "$${csvFileNext}"
 	sed -ri "s/version: [0-9]+.[0-9]+.[0-9]/version: $${version}/g" "$${csvFileNext}"
 	sed -ri "s/replaces: kubernetes-imagepuller-operator.v[0-9]+.[0-9]+.[0-9]/replaces: kubernetes-imagepuller-operator.$${previousPackageVersion}/g" "$${csvFileNext}"
-	sed -ri "s|image: quay.io/eclipse/kubernetes-image-puller-operator:next|image: quay.io/eclipse/kubernetes-image-puller-operator:$${version}|g" "$${csvFileNext}"
+	sed -ri "s|image: quay.io/eclipse/kubernetes-image-puller-operator:[0-9]+.[0-9]+.[0-9]|image: quay.io/eclipse/kubernetes-image-puller-operator:$${version}|g" "$${csvFileNext}"
 
 	mkdir -p "$${packageVersionPath}"
 


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

In line 245 of the makefile, the `$${csvFileNext}` file (which is bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml) does not have a KIPO image with a `next` tag. Instead, the tag is a version number: https://github.com/che-incubator/kubernetes-image-puller-operator/blob/da50201ee5438043f77af40a8c1352c638275d4c/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml#L118

This PR updates the sed command to address this