### PR TITLE
fix: update 1.0.2 CSV deployment image

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubernetes-image-puller-operator
-                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.1
+                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.2
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.2/kubernetes-imagepuller-operator.v1.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.2/kubernetes-imagepuller-operator.v1.0.2.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubernetes-image-puller-operator
-                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.1
+                image: quay.io/eclipse/kubernetes-image-puller-operator:1.0.2
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Sorry I don't know why this change wasn't done on as part of https://github.com/che-incubator/kubernetes-image-puller-operator/pull/83

Undoing the [release commit](https://github.com/che-incubator/kubernetes-image-puller-operator/pull/83/commits/97a808f2a49de4714e333a4cf6713989a1192a8e) locally, and then after trying `make release-bundle -s RELEASE_VERSION=1.0.2` again, it's now being updated. Still a mystery to me why it didn't work before.