### PR TITLE
Update kube-rbac-proxy image and release 1.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.2
+VERSION ?= 1.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/che.eclipse.org_kubernetesimagepullers_crd.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/che.eclipse.org_kubernetesimagepullers_crd.yaml
@@ -1,0 +1,82 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: kubernetesimagepullers.che.eclipse.org
+spec:
+  group: che.eclipse.org
+  names:
+    kind: KubernetesImagePuller
+    listKind: KubernetesImagePullerList
+    plural: kubernetesimagepullers
+    singular: kubernetesimagepuller
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KubernetesImagePuller is the Schema for the kubernetesimagepullers
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubernetesImagePullerSpec defines the desired state of KubernetesImagePuller
+            properties:
+              affinity:
+                type: string
+              cachingCPULimit:
+                type: string
+              cachingCPURequest:
+                type: string
+              cachingIntervalHours:
+                type: string
+              cachingMemoryLimit:
+                type: string
+              cachingMemoryRequest:
+                type: string
+              configMapName:
+                type: string
+              daemonsetName:
+                type: string
+              deploymentName:
+                type: string
+              imagePullSecrets:
+                type: string
+              imagePullerImage:
+                type: string
+              images:
+                type: string
+              nodeSelector:
+                type: string
+            type: object
+          status:
+            description: KubernetesImagePullerStatus defines the observed state of
+              KubernetesImagePuller
+            properties:
+              imagePullerImage:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/controller-manager-metrics-service_v1_service.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    name: kubernetes-image-puller-operator
+  name: controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    name: kubernetes-image-puller-operator
+status:
+  loadBalancer: {}

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/kubernetes-imagepuller-operator.v1.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/kubernetes-imagepuller-operator.v1.0.3.clusterserviceversion.yaml
@@ -277,7 +277,7 @@ spec:
   provider:
     name: Red Hat, Inc.
     url: https://github.com/che-incubator/kubernetes-image-puller-operator
-  replaces: kubernetes-imagepuller-operator.v1.0.2
+  replaces: kubernetes-imagepuller-operator.v1.0.3
   selector:
     matchLabels:
       app: kubernetes-image-puller-operator

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/kubernetes-imagepuller-operator.package.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/kubernetes-imagepuller-operator.package.yaml
@@ -2,4 +2,4 @@ packageName: kubernetes-imagepuller-operator
 defaultChannel: stable
 channels:
   - name: stable
-    currentCSV: kubernetes-imagepuller-operator.v1.0.2
+    currentCSV: kubernetes-imagepuller-operator.v1.0.3

--- a/version/version.go
+++ b/version/version.go
@@ -13,5 +13,5 @@
 package version
 
 var (
-	Version = "1.0.2"
+	Version = "1.0.3"
 )


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Fixes: https://issues.redhat.com/browse/CRW-3379

The kube-rbac-proxy image has been updated from  `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` to `quay.io/brancz/kube-rbac-proxy:v0.11.0`.

Things to note:
* The `kubebuilder/kube-rbac-proxy` is built from the `brancz/kube-rbac-proxy` image, see [here](https://github.com/kubernetes-sigs/kubebuilder/blob/91a1afa8fe9ef2a451c66549039e012c0702baa1/RELEASE.md#to-build-the-kube-rbac-proxy-images).
* According to the [changelog](https://github.com/brancz/kube-rbac-proxy/blob/master/CHANGELOG.md#0110--2021-08-02), the difference between the `v0.8.0` version and the `v0.11.0` shows that there are no breaking changes regarding args/flags

To test, run:
```
make deploy IMG="quay.io/dkwon17/kubernetes-image-puller-operator:next" -s
```
to deploy the KIPO and verify that the `quay.io/brancz/kube-rbac-proxy:v0.11.0` image is running in the KIPO pod.
