### PR TITLE
fix: update spec.replaces from the 1.0.3 CSV

### DIFF
--- a/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/kubernetes-imagepuller-operator.v1.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubernetes-imagepuller-operator/1.0.3/kubernetes-imagepuller-operator.v1.0.3.clusterserviceversion.yaml
@@ -277,7 +277,7 @@ spec:
   provider:
     name: Red Hat, Inc.
     url: https://github.com/che-incubator/kubernetes-image-puller-operator
-  replaces: kubernetes-imagepuller-operator.v1.0.3
+  replaces: kubernetes-imagepuller-operator.v1.0.2
   selector:
     matchLabels:
       app: kubernetes-image-puller-operator


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

The makefile (ie `make release-bundle -s RELEASE_VERSION=1.0.3`) should have made this change in https://github.com/che-incubator/kubernetes-image-puller-operator/pull/86

I tried running `make release-bundle -s RELEASE_VERSION=1.0.3` again and now, the change is being made correctly. I'm not sure why this change didn't go through for https://github.com/che-incubator/kubernetes-image-puller-operator/pull/86