### PR TITLE
Update try-in-web-ide GH action to latest 1.x.x version

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@v1.2
+        uses: redhat-actions/try-in-web-ide@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the [try-in-web-ide](https://github.com/redhat-actions/try-in-web-ide) github action to use the latest 1.x.x version.

With this version, there will not be multiple comment badges whenever there is an update (i.e. new commit push, force push) to a PR like we see in this PR: https://github.com/che-incubator/kubernetes-image-puller-operator/pull/115