### PR TITLE
Use gh instead of hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
           echo "RELEASE_VERSION=${RELEASE_VERSION}"
           BRANCH=${RELEASE_VERSION%.*}.x
           echo "BRANCH=${BRANCH}"
-          hub version
           git config --global user.name "Anatolii Bazko"
           git config --global user.email "abazko@redhat.com"
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}

--- a/make-release.sh
+++ b/make-release.sh
@@ -180,7 +180,7 @@ createPRToMainBranch() {
   fi
   git push origin $tmpBranch -f
   if [[ $FORCE_UPDATE == "--force" ]]; then set +e; fi  # don't fail if PR already exists (just force push commits into it)
-  hub pull-request $FORCE_UPDATE --base main --head ${tmpBranch} -m "ci: Copy ${RELEASE_VERSION} bundle to main"
+  gh pr create -f -B main -H ${tmpBranch} -t "ci: Copy ${RELEASE_VERSION} bundle to main"
   set -e
 }
 


### PR DESCRIPTION
Resolves release build failure: https://github.com/che-incubator/kubernetes-image-puller-operator/actions/runs/7263410554/job/19788646074

`gh pr create` documentation: https://cli.github.com/manual/gh_pr_create
`hub pull-request` documentation: https://hub.github.com/hub-pull-request.1.html