### PR TITLE
Update "createdAt" and "support" annotation in CSV

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -32,12 +32,12 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/kubernetes-image-puller-operator:1.1.0
-    createdAt: ""
+    createdAt: "2024-01-15T16:23:04Z"
     description: Create and manage kubernetes-image-puller instances.
     operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/che-incubator/kubernetes-image-puller-operator
-    support: ""
+    support: Community
   name: kubernetes-imagepuller-operator.v1.1.0
   namespace: placeholder
 spec:

--- a/config/manifests/bases/kubernetes-image-puller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kubernetes-image-puller-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     createdAt: ""
     description: Create and manage kubernetes-image-puller instances.
     repository: https://github.com/che-incubator/kubernetes-image-puller-operator
-    support: ""
+    support: Community
   name: kubernetes-imagepuller-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/make-release.sh
+++ b/make-release.sh
@@ -97,10 +97,12 @@ releaseOlmFiles() {
   CURRENT_VERSION=$(make bundle-version)
   PACKAGE=$(make bundle-package)
   CSV_PATH=$(make csv-path)
+  CREATE_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%SZ")
 
   make bundle IMG="${RELEASE_IMAGE}"
 
   yq -riY '.metadata.name = "'${PACKAGE}'.v'${RELEASE_VERSION}'"' ${CSV_PATH}
+  yq -riY '.metadata.annotations.createdAt = "'${CREATE_TIMESTAMP}'"' ${CSV_PATH}
   yq -riY '.spec.version = "'${RELEASE_VERSION}'"' ${CSV_PATH}
   yq -riY '.spec.replaces = "'${PACKAGE}'.v'${CURRENT_VERSION}'"' ${CSV_PATH}
 


### PR DESCRIPTION
Adds values for the the `metadata.annotations.support` and `metadata.annotations.createdAt` annotations in the CSV.

This is because these fields are now required for releasing the operator for [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod), see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3848#issuecomment-1881787781


For reference, this is how the Eclipse Che CSV defines the `support` and `createdAt` annotations: https://github.com/eclipse-che/che-operator/blob/c738dc70fc75721a50c8cc362d087c7b3b6c4979/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml#L70-L79

To create this PR, I manually edited `config/manifests/bases/kubernetes-image-puller-operator.clusterserviceversion.yaml` to add the `support` annotation. I then ran:
```
make bundle
CSV_PATH=$(make csv-path)
CREATE_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%SZ")
yq -riY '.metadata.annotations.createdAt = "'${CREATE_TIMESTAMP}'"' ${CSV_PATH}
```