### PR TITLE
Update CI workflows and harden security contexts

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -21,50 +21,38 @@ jobs:
     steps:
     -
       name: "Set up QEMU"
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     -
       name: "Set up Docker Buildx"
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     -
       name: "Docker quay.io Login"
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-    - 
+    -
       name: Clone source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - 
+        persist-credentials: false
+    -
       name: Prepare
       id: prep
       run: |
         set -e
         SHORT_SHA1=$(git rev-parse --short HEAD)
-        echo ::set-output name=short_sha1::${SHORT_SHA1}
-        echo ::set-output name=version::next
+        echo "short_sha1=${SHORT_SHA1}" >> $GITHUB_OUTPUT
+        echo "version=next" >> $GITHUB_OUTPUT
         IMAGE=kubernetes-image-puller-operator
-        echo ::set-output name=image::${IMAGE}
+        echo "image=${IMAGE}" >> $GITHUB_OUTPUT
     -
       name: "Build and push"
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./build/Dockerfile
         tags:  quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }},quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.short_sha1 }}
         push: true
-#    -
-#      name: Create failure MM message
-#      if: ${{ failure() }}
-#      run: |
-#        echo "{\"text\":\":no_entry_sign: Kubernetes Image puller Operator build has failed: https://github.com/che-incubator/kubernetes-image-puller-operator/actions/workflows/next-build.yml\"}" > mattermost.json
-#    -
-#      name: Send MM message
-#      if: ${{ failure() }}
-#      uses: mattermost/action-mattermost-notify@1.1.0
-#      env:
-#        MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-#        MATTERMOST_CHANNEL: eclipse-che-ci
-#        MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,40 +12,45 @@
 
 name: PR check
 on: pull_request
+permissions:
+  contents: read
 jobs:
   unit-tests:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
-    - name: Set up Go 1.21
-      uses: actions/setup-go@v3
+      uses: actions/checkout@v4
       with:
-        go-version: 1.21
+        persist-credentials: false
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
     - name: Run unit tests
       run: make test
   image-build:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Build image
-      run: docker build -f build/Dockerfile --build-arg SKIP_TESTS=true . 
+      run: docker build -f build/Dockerfile --build-arg SKIP_TESTS=true .
   scorecard:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Start minikube cluster
         id: run-minikube
         uses: che-incubator/setup-minikube-action@next
         with:
-          minikube-version: v1.23.2
+          minikube-version: v1.34.0
       - name: Run tests
-        run: | 
+        run: |
           make download-operator-sdk
-          # Workaround, install specific version of OLM
-          # There is no crds.yaml in the latest release to deploy OLM 
-          bin/operator-sdk olm install --version v0.28.0          
+          bin/operator-sdk olm install --version v0.28.0
           bin/operator-sdk scorecard bundle
-        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check existing tags
@@ -46,27 +46,27 @@ jobs:
             echo "[INFO] No existing tags detected for $VERSION"
           fi
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker quay.io Login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install yq
         run: |
           python -m pip install --upgrade pip
           pip install yq
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: '1.22'
       - name: Release operator
         run: |
           RELEASE_VERSION=${{ github.event.inputs.version }}
@@ -76,7 +76,7 @@ jobs:
           git config --global user.name "Anatolii Bazko"
           git config --global user.email "abazko@redhat.com"
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
-          
+
           set -e
 
           if [[ ${{ github.event.inputs.forceRecreateTags }} == "true" ]]; then force_update="--force"; fi
@@ -85,4 +85,4 @@ jobs:
             --release-olm-files \
             --release-olm-bundle \
             --push-git-changes \
-            --pull-requests 
+            --pull-requests

--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ download-operator-sdk: ## Downloads operator sdk tool
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 download-controller-gen: ## Download controller-gen tool
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 download-kustomize: ## Download kustomize tool

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,10 @@ spec:
         name: kubernetes-image-puller-operator
     spec:
       serviceAccountName: $(CONTROLLER_SERVICE_ACCOUNT)
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: kubernetes-image-puller-operator
         image: quay.io/eclipse/kubernetes-image-puller-operator:next
@@ -35,6 +39,15 @@ spec:
         args:
         - --leader-elect
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         env:
           - name: WATCH_NAMESPACE
             valueFrom:
@@ -65,4 +78,7 @@ spec:
           requests:
             cpu: 100m
             memory: 64Mi
+      volumes:
+      - name: tmp
+        emptyDir: {}
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Summary

Resolves #178

- Upgrade all GitHub Actions to latest major versions (checkout v4, setup-go v5, docker actions v3/v6, setup-python v5)
- Update Go version in CI from 1.21 to 1.22
- Update minikube from v1.23.2 to v1.34.0
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT` in next-build workflow
- Add pod-level `runAsNonRoot: true`
- Add container-level `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `capabilities.drop: ["ALL"]`

## Test plan

- [ ] PR check workflow runs successfully
- [ ] Operator deploys with restricted pod security standard
- [ ] Health/readiness probes still work with read-only root filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build, test, and release automation to use newer supported tooling, improving reliability and reducing workflow failures.
  * Refined release step formatting to ensure release commands run as expected.

* **Style**
  * Cleaned up workflow scripts and removed outdated syntax.

* **Chores**
  * Strengthened runtime container security by running as non-root, restricting privilege escalation, and using a read-only filesystem with a writable temporary directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->