### PR TITLE
Add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+This project follows the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 1.1.x   | :white_check_mark: |
+| < 1.1   | :x:                |
+
+## How To Report a Vulnerability
+
+If you believe you have discovered a vulnerability in this project, please report it through coordinated disclosure.
+
+**Do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please use one of the following methods:
+
+- Report via [GitHub private vulnerability reporting](https://github.com/che-incubator/kubernetes-image-puller-operator/security/advisories/new)
+- Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+
+For more information, visit the [Eclipse Foundation Security](https://www.eclipse.org/security/) page.
+
+## Information to Include
+
+Please provide as much of the following as possible to help us triage your report:
+
+- Type of issue (e.g., privilege escalation, container escape, RBAC bypass)
+- Affected version(s)
+- Impact of the issue, including how an attacker might exploit it
+- Step-by-step instructions to reproduce
+- Location of affected source code (tag/branch/commit or direct URL)
+- Any relevant configuration required to reproduce
+- Proof-of-concept or exploit code (if possible)


### PR DESCRIPTION
## Summary

Resolves #182

Adds a `SECURITY.md` based on the [Eclipse Foundation security handbook template](https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md), directing vulnerability reporters to GitHub private advisory reporting and the Eclipse Foundation's confidential tracker.

## Test plan

- [x] File follows Eclipse Foundation template structure
- [ ] GitHub security policy warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)