### PR TITLE
chore: Update kube-rbac-proxy from v0.11.0 to v0.20.0

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -192,7 +192,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=10
-                    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+                    image: quay.io/brancz/kube-rbac-proxy:v0.20.0
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.20.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
-# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# the auth proxy (https://github.com/kube-rbac-proxy/kube-rbac-proxy)
 # which protects your /metrics endpoint.
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml


### PR DESCRIPTION
## Summary

- Update `kube-rbac-proxy` sidecar image from `v0.11.0` to `v0.20.0` to resolve known CVEs
- Update project URL in RBAC kustomization comment to reflect the org move to `kube-rbac-proxy/kube-rbac-proxy`
- Regenerate bundle CSV with the new image tag

Historical OLM catalog bundles in `olm-catalog/stable/` are intentionally left unchanged.

Closes #187
Relates #153

Signed-off-by: Chris Brown <snecklifter@users.noreply.github.com>