### PR TITLE
feat: Support image digest pinning for disconnected environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,15 @@ compile:
 
 ##@ OLM catalog
 
+# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command.
+# To pin image tags to digests for disconnected/air-gapped environments, run:
+#   make bundle USE_IMAGE_DIGESTS=true
+BUNDLE_GEN_FLAGS ?= --quiet --overwrite --version $(VERSION) --package $(PACKAGE) --channels $(CHANNEL) --default-channel $(CHANNEL)
+USE_IMAGE_DIGESTS ?= false
+ifeq ($(USE_IMAGE_DIGESTS), true)
+BUNDLE_GEN_FLAGS += --use-image-digests
+endif
+
 .PHONY: bundle
 bundle: generate manifests download-kustomize download-operator-sdk ## Generate OLM bundle
 	echo "[INFO] Updating OperatorHub bundle"
@@ -179,13 +188,8 @@ bundle: generate manifests download-kustomize download-operator-sdk ## Generate 
 
 	$(KUSTOMIZE) build config/openshift/olm | \
 	$(OPERATOR_SDK) generate bundle \
-	--quiet \
-	--overwrite \
-	--version $(VERSION) \
-	--package $(PACKAGE) \
-	--output-dir $${BUNDLE_PATH} \
-	--channels $(CHANNEL) \
-	--default-channel $(CHANNEL)
+	$(BUNDLE_GEN_FLAGS) \
+	--output-dir $${BUNDLE_PATH}
 
 	CSV_PATH=$$($(MAKE) csv-path)
 	yq -riY '.metadata.annotations.containerImage = "'$(IMG)'"' $${CSV_PATH}


### PR DESCRIPTION
## Summary

- Adds `BUNDLE_GEN_FLAGS` variable to the Makefile with support for `USE_IMAGE_DIGESTS`
- Running `make bundle USE_IMAGE_DIGESTS=true` pins image tags to digests in the OLM bundle, enabling deployment in disconnected/air-gapped environments
- Follows the standard kubebuilder pattern for disconnected environment support

Fixes #125

## Test plan

- [ ] `make bundle` continues to work as before (no behavioural change without the flag)
- [ ] `make bundle USE_IMAGE_DIGESTS=true` generates a bundle with image digests pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the bundle generation process by centralizing its options, making release builds easier to maintain.
  * Added support for generating bundles with image digests when that mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->