### PR TITLE
fix: Pin setup-envtest to release-0.19 for Go 1.22 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test: manifests generate fmt vet download-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/testbin -p path)" go test ./... -coverprofile cover.out
 
 download-envtest: ## Download setup-envtest tool
-	test -s $(ENVTEST) || GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(ENVTEST) || GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 
 # Set a new operator image for kustomize
 kustomize-operator-image: download-kustomize


### PR DESCRIPTION
## Summary

- `setup-envtest@latest` now resolves to v0.24.1 which requires Go >= 1.26.0
- The build image uses Go 1.22.9, causing all CI builds on `main` to fail with:
  `sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.1 requires go >= 1.26.0 (running go 1.22.9; GOTOOLCHAIN=local)`
- Pins `setup-envtest` to `@release-0.19`, the latest branch compatible with Go 1.22

## Test plan

- [ ] CI `build-next` workflow passes on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)