### PR TITLE
fix: pin GitHub Actions to SHA digests and update to Node 24

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -21,20 +21,20 @@ jobs:
     steps:
     -
       name: "Set up QEMU"
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
     -
       name: "Set up Docker Buildx"
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
     -
       name: "Docker quay.io Login"
-      uses: docker/login-action@v3
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     -
       name: Clone source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -50,7 +50,7 @@ jobs:
         echo "image=${IMAGE}" >> $GITHUB_OUTPUT
     -
       name: "Build and push"
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: .
         file: ./build/Dockerfile

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.22'
     - name: Run unit tests
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
     - name: Build image
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
       - name: Start minikube cluster
         id: run-minikube
-        uses: che-incubator/setup-minikube-action@next
+        uses: che-incubator/setup-minikube-action@fbf2aa1144e0088e9200fc2ecf5e26040ea2a8e4 # next
         with:
           minikube-version: v1.34.0
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
       - name: Check existing tags
@@ -46,17 +46,17 @@ jobs:
             echo "[INFO] No existing tags detected for $VERSION"
           fi
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Docker quay.io Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.9
       - name: Install yq
@@ -64,7 +64,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install yq
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.22'
       - name: Release operator

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@v1
+        uses: redhat-actions/try-in-web-ide@b0759ad32b1690a3a619c291eebc207c7037c9f6 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions to SHA digests instead of mutable version tags to prevent supply chain attacks
- Updates to Node 24-compatible versions, resolving punycode deprecation warnings and Node 20 deprecation notices

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `@v4` | `@v7` (SHA pinned) |
| `actions/setup-go` | `@v5` | `@v6` (SHA pinned) |
| `actions/setup-python` | `@v5` | `@v6` (SHA pinned) |
| `docker/setup-qemu-action` | `@v3` | `@v4` (SHA pinned) |
| `docker/setup-buildx-action` | `@v3` | `@v4` (SHA pinned) |
| `docker/login-action` | `@v3` | `@v4` (SHA pinned) |
| `docker/build-push-action` | `@v6` | `@v7` (SHA pinned) |
| `redhat-actions/try-in-web-ide` | `@v1` | SHA pinned (no Node 24 version available) |
| `che-incubator/setup-minikube-action` | `@next` | SHA pinned |

## Test plan

- [ ] PR check workflow runs without Node 20 deprecation or punycode warnings
- [ ] Unit tests, image build, and scorecard jobs pass
- [ ] Build and release workflows validated on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)