### PR TITLE
fix: Re-enable CGO for operator builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ compile:
 	if [ -z "$${binary}" ]; then
 		binary="/tmp/image-puller/kubernetes-image-puller-operator"
 	fi
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -a -o "$${binary}" main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GO111MODULE=on go build -a -o "$${binary}" main.go
 	echo "kubernetes-image-puller-operator binary compiled to $${binary}"
 
 ##@ OLM catalog

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,7 +36,7 @@ COPY config/webhook/ config/webhook/
 # Test
 RUN if [[ ${SKIP_TESTS} == "false" ]]; then make test; fi
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # https://catalog.redhat.com/software/containers/ubi9-minimal
 FROM registry.access.redhat.com/ubi9-minimal:9.5


### PR DESCRIPTION
## Summary
- CGO was explicitly disabled (`CGO_ENABLED=0`) in the `compile` Makefile target and the Dockerfile, producing statically linked binaries
- Re-enables CGO (`CGO_ENABLED=1`) to allow use of cgo-dependent packages and match the default Go toolchain behaviour

## Test plan
- [x] `make test` — all tests pass
- [x] `make build` — builds successfully
- [x] `make compile` — compiles successfully, binary is dynamically linked
- [x] Verified binary with `file` and `ldd` confirming dynamic linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux amd64 build process to enable CGO, aligning build settings across packaging steps.
  * This should improve compatibility for builds that rely on native system integration during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->