### PR TITLE
fix: pin try-in-web-ide GitHub Action to v1.5.0

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@b0759ad32b1690a3a619c291eebc207c7037c9f6 # v1
+        uses: redhat-actions/try-in-web-ide@6d64b671fa7f83b770c5dd1d1094559a509d2a50 # v1.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update `redhat-actions/try-in-web-ide` SHA digest from v1 (`b0759ad`) to v1.5.0 (`6d64b67`)

## Test plan
- [x] Workflow file syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)