### PR TITLE
fix: tighten RBAC permissions to least privilege

### DIFF
--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -237,71 +237,65 @@ spec:
                 - ""
               resources:
                 - pods
-                - services
-                - services/finalizers
-                - endpoints
-                - persistentvolumeclaims
-                - events
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
                 - configmaps
-                - secrets
-                - serviceaccounts
               verbs:
                 - create
                 - delete
                 - get
                 - list
-                - patch
                 - update
                 - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
             - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
                 - roles
                 - rolebindings
               verbs:
+                - create
+                - delete
                 - get
                 - list
                 - watch
-                - create
-                - delete
             - apiGroups:
                 - apps
               resources:
                 - deployments
-                - daemonsets
-                - replicasets
-                - statefulsets
               verbs:
                 - create
                 - delete
                 - get
                 - list
-                - patch
                 - update
                 - watch
             - apiGroups:
                 - apps
               resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
+                - daemonsets
               verbs:
                 - get
-                - create
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-              verbs:
-                - get
+                - list
+                - watch
             - apiGroups:
                 - che.eclipse.org
               resources:
-                - '*'
+                - kubernetesimagepullers
+                - kubernetesimagepullers/status
+                - kubernetesimagepullers/finalizers
               verbs:
                 - create
                 - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,71 +20,65 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
-  - secrets
-  - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
   - rolebindings
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch
-  - create
-  - delete
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
+  - daemonsets
   verbs:
   - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
+  - list
+  - watch
 - apiGroups:
   - che.eclipse.org
   resources:
-  - '*'
+  - kubernetesimagepullers
+  - kubernetesimagepullers/status
+  - kubernetesimagepullers/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Summary
- Replace `che.eclipse.org/*` wildcard with specific resources (`kubernetesimagepullers`, `kubernetesimagepullers/status`, `kubernetesimagepullers/finalizers`)
- Remove unused core API resources: `secrets`, `persistentvolumeclaims`, `endpoints`, `services`, `services/finalizers`, `events`
- Remove unused apps resources: `replicasets`, `statefulsets`, `deployments/finalizers`
- Remove unused `monitoring.coreos.com/servicemonitors`
- Remove duplicate `pods` entry
- Scope each resource to only the verbs the controller actually uses

Updates both `config/rbac/role.yaml` and the OLM bundle CSV permissions.

## Why

The existing RBAC grants the operator full CRUD access to resources it never touches (secrets, PVCs, endpoints, etc.) and uses a `*` wildcard on the `che.eclipse.org` API group. This violates least-privilege and expands the blast radius if the operator is compromised.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./controllers/...` passes
- [x] Permissions audited against every `r.Get`, `r.Create`, `r.Update`, `r.Delete`, `r.List`, and `r.Status().Update` call in the controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)