### PR TITLE
fix: add security context and resource limits to managed deployment

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -290,6 +291,9 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 
 func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Deployment {
 	replicas := int32(1)
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
 	var deploymentName string
 	if cr.Spec.DeploymentName == "" {
 		deploymentName = "kubernetes-image-puller"
@@ -317,10 +321,33 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Dep
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "k8s-image-puller",
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &runAsNonRoot,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "kubernetes-image-puller",
 							Image: cr.Spec.ImagePullerImage,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
 							Env: []corev1.EnvVar{{
 								Name:  "DEPLOYMENT_NAME",
 								Value: deploymentName,


### PR DESCRIPTION
## Summary
- Add pod-level security context: `runAsNonRoot`, `seccompProfile: RuntimeDefault`
- Add container-level security context: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, drop all capabilities
- Add resource requests (50m CPU, 64Mi memory) and limits (200m CPU, 256Mi memory)

## Why

The operator's own deployment (`config/manager/manager.yaml`) correctly sets security contexts and resource limits, but the deployment it creates for the image puller has none. This means the managed deployment doesn't meet pod security standards and has no resource bounds.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./controllers/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload security by running containers with stricter default protections and reduced privileges.
  * Added CPU and memory requests and limits to help deployments behave more predictably under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->