### PR TITLE
fix: remove unnecessary Owns watches for Pods and DaemonSets

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -349,9 +349,7 @@ func GetDeploymentConfigMapName(deployment *appsv1.Deployment) string {
 func (r *KubernetesImagePullerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&chev1alpha1.KubernetesImagePuller{}).
-		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Pod{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary
- Remove `Owns(&appsv1.DaemonSet{})` and `Owns(&corev1.Pod{})` from `SetupWithManager`

## Why

The controller does not directly create Pods or DaemonSets. Pods are created by the Deployment controller, and DaemonSets are created by the image puller application itself at runtime. Neither will have `OwnerReferences` pointing to the `KubernetesImagePuller` CR, so these watches either do nothing or cause unnecessary reconcile cycles.

The controller only creates Deployments and ConfigMaps with proper owner references, so those are the only `Owns()` watches needed.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./controllers/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)