### PR TITLE
fix: remove dead ConfigMap rename code and rely on cleanup path

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -201,37 +201,25 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Find all configmaps owned by this imagepuller and delete ones that are not named ConfigMapName
+	// Clean up any old ConfigMaps owned by this instance that no longer match the desired name
 	configMaps := &corev1.ConfigMapList{}
-	if err = r.List(ctx, configMaps, client.MatchingLabels{"app": defaults.AppLabelValue}); err != nil {
+	if err = r.List(ctx, configMaps, client.InNamespace(instance.Namespace), client.MatchingLabels{"app": defaults.AppLabelValue}); err != nil {
 		log.Error(err, "Could not list ConfigMaps")
 		return ctrl.Result{}, err
-	} else {
-
-		for _, cm := range configMaps.Items {
-			if cm.Name != instance.Spec.ConfigMapName && len(cm.OwnerReferences) > 0 {
-				if cm.OwnerReferences[0].Name == instance.Name {
+	}
+	for _, cm := range configMaps.Items {
+		if cm.Name != instance.Spec.ConfigMapName {
+			for _, ownerRef := range cm.OwnerReferences {
+				if ownerRef.Name == instance.Name {
+					log.Info("Deleting old ConfigMap after rename", "ConfigMap.Name", cm.Name, "NewConfigMap.Name", instance.Spec.ConfigMapName)
 					if err = r.Delete(ctx, &cm); err != nil {
 						log.Error(err, "Could not delete ConfigMap")
 						return ctrl.Result{}, err
 					}
+					break
 				}
 			}
 		}
-	}
-
-	// Create a new ConfigMap if the names differ
-	if foundConfigMap.Name != instance.Spec.ConfigMapName {
-		newConfigMap := config.NewImagePullerConfigMap(instance)
-		if err = r.Create(ctx, newConfigMap); err != nil {
-			log.Error(err, "Could not create new ConfigMap")
-			return ctrl.Result{}, err
-		}
-		if err = r.Delete(ctx, foundConfigMap); err != nil {
-			log.Error(err, "Could not delete old ConfigMap")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
 	}
 
 	// Check if kubernetes image puller deployment exists, and create it if it does not.

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -819,6 +819,59 @@ func TestAnnotationRolloutOnConfigMapChange(t *testing.T) {
 	}
 }
 
+func TestDeletesOldConfigMapOnRename(t *testing.T) {
+	oldConfigMap := expectedConfigMap(defaultImagePullerWithConfigMapNameAndDeploymentName())
+	cr := &chev1alpha1.KubernetesImagePuller{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-puller",
+		},
+		Spec: chev1alpha1.KubernetesImagePullerSpec{
+			ConfigMapName:  "new-configmap",
+			DeploymentName: defaultDeploymentName,
+		},
+	}
+
+	c := setupClient(t, cr, oldConfigMap, NewImagePullerDeployment(cr, false),
+		createDaemonsetRole, createDaemonsetRoleBinding, defaultServiceAccount)
+	r := &KubernetesImagePullerReconciler{
+		Client: c,
+		Scheme: scheme.Scheme,
+		Log:    ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+	}
+
+	// First reconcile: creates the new ConfigMap
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("First reconcile error: %v", err)
+	}
+
+	// Verify intermediate state: both old and new ConfigMaps should exist
+	configMaps := &corev1.ConfigMapList{}
+	if err := c.List(context.TODO(), configMaps, client.MatchingLabels{"app": "kubernetes-image-puller"}); err != nil {
+		t.Fatalf("Error listing ConfigMaps after first reconcile: %v", err)
+	}
+	if len(configMaps.Items) != 2 {
+		t.Fatalf("Expected 2 ConfigMaps after first reconcile but got %v", len(configMaps.Items))
+	}
+
+	// Second reconcile: cleans up the old ConfigMap
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Second reconcile error: %v", err)
+	}
+
+	configMaps = &corev1.ConfigMapList{}
+	if err := c.List(context.TODO(), configMaps, client.MatchingLabels{"app": "kubernetes-image-puller"}); err != nil {
+		t.Fatalf("Error listing ConfigMaps: %v", err)
+	}
+
+	if len(configMaps.Items) != 1 {
+		t.Fatalf("Expected 1 ConfigMap but got %v", len(configMaps.Items))
+	}
+	if configMaps.Items[0].Name != "new-configmap" {
+		t.Errorf("Expected ConfigMap named 'new-configmap' but got '%v'", configMaps.Items[0].Name)
+	}
+}
+
 func TestDeletesOldDeploymentOnNameChange(t *testing.T) {
 	type testcase struct {
 		name  string


### PR DESCRIPTION
## Summary
- Removes unreachable code block (old lines 213-225) that attempted to create a new ConfigMap and delete the old one on rename — this could never execute because `foundConfigMap` is always fetched by `instance.Spec.ConfigMapName`, so the names always match at that point
- Renames are already handled correctly by the create-if-missing path followed by the orphan cleanup loop on subsequent reconciles
- Adds a log message when cleaning up old ConfigMaps after a rename
- Adds `TestDeletesOldConfigMapOnRename` test verifying the full rename flow across two reconcile calls

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/...` passes (all existing + new test)
- [ ] Manual verification: change `spec.configMapName` on a running CR and confirm old ConfigMap is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of outdated ConfigMaps when the configured ConfigMap name changes.
  * Cleanup now considers only ConfigMaps in the instance’s namespace (while still using the app label) and removes only the ConfigMaps owned by the current instance.

* **Tests**
  * Added a controller test to verify rename behavior: the old ConfigMap is removed after the second reconcile, while the new ConfigMap remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->