### PR TITLE
fix: use annotation-triggered rollout instead of deleting pods

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -14,7 +14,11 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/config"
@@ -141,6 +145,18 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Update the ConfigMap before triggering a rollout so new pods
+	// always read the persisted data.
+	newConfigMap := config.NewImagePullerConfigMap(instance)
+	configMapUpdated := false
+	if config.ConfigMapsDiffer(newConfigMap, foundConfigMap) {
+		if err = r.Update(context.TODO(), newConfigMap); err != nil {
+			r.Log.Error(err, "Error updating configmap")
+			return ctrl.Result{}, err
+		}
+		configMapUpdated = true
+	}
+
 	// If there is an existing deployment, roll it out on configmap change
 	oldDeployment := &appsv1.Deployment{}
 	if err = r.Get(ctx, types.NamespacedName{Name: instance.Spec.DeploymentName, Namespace: instance.Namespace}, oldDeployment); err != nil && !errors.IsNotFound(err) {
@@ -152,25 +168,18 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 			log.Error(err, "Error reading configmap name from deployment")
 			return ctrl.Result{}, err
 		}
-		if config.ConfigMapsDiffer(config.NewImagePullerConfigMap(instance), foundConfigMap) || oldConfigMapName != foundConfigMap.Name {
+		if configMapUpdated || oldConfigMapName != foundConfigMap.Name {
 			if oldConfigMapName == foundConfigMap.Name {
-				// ConfigMap names are the same, delete pods and let the new pods pick up the new configmap
-
-				pods := &corev1.PodList{}
-				if err = r.List(ctx, pods, client.MatchingLabels{"app": defaults.AppLabelValue}); err != nil {
-					log.Error(err, "Error listing pods")
+				desiredHash := configMapDataHash(newConfigMap.Data)
+				if oldDeployment.Spec.Template.Annotations == nil {
+					oldDeployment.Spec.Template.Annotations = make(map[string]string)
+				}
+				oldDeployment.Spec.Template.Annotations["che.eclipse.org/configmap-hash"] = desiredHash
+				log.Info("ConfigMap content changed, triggering rolling restart")
+				if err = r.Update(ctx, oldDeployment); err != nil {
+					log.Error(err, "Error updating deployment for rollout")
 					return ctrl.Result{}, err
 				}
-				if len(pods.Items) > 0 {
-					for _, pod := range pods.Items {
-						log.Info("Deleting pod", "Pod.Name", pod.Name)
-						if err = r.Delete(ctx, &pod); err != nil {
-							log.Error(err, "Error deleting pod", "Pod.Name", pod.Name)
-							return ctrl.Result{}, err
-						}
-					}
-				}
-				// ConfigMap names are different, just run an update
 			} else {
 				err = r.Update(ctx, NewImagePullerDeployment(instance, r.IsOpenShift))
 				if err != nil {
@@ -181,14 +190,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	// If the configmap has already been created and the values have changed, update the configmap.
-	newConfigMap := config.NewImagePullerConfigMap(instance)
-	if config.ConfigMapsDiffer(newConfigMap, foundConfigMap) {
-		if err = r.Update(ctx, newConfigMap); err != nil {
-			log.Error(err, "Error updating configmap")
-			return ctrl.Result{}, err
-		}
-
+	if configMapUpdated {
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -394,6 +396,21 @@ func getContainerSecurityContext(isOpenShift bool) *corev1.SecurityContext {
 	}
 
 	return ctx
+}
+
+func configMapDataHash(data map[string]string) string {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	raw, _ := json.Marshal(keys)
+	for _, k := range keys {
+		v, _ := json.Marshal(data[k])
+		raw = append(raw, v...)
+	}
+	hash := sha256.Sum256(raw)
+	return hex.EncodeToString(hash[:])
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -812,6 +812,39 @@ func TestUpdatesConfigMap(t *testing.T) {
 	}
 }
 
+func TestAnnotationRolloutOnConfigMapChange(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()
+	cr.Spec.DaemonsetName = "new-daemonset"
+	oldConfigMap := expectedConfigMap(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage())
+	deployment := NewImagePullerDeployment(cr, false)
+	deployment.ResourceVersion = "1"
+
+	c := setupClient(t, cr, oldConfigMap, deployment,
+		createDaemonsetRole, createDaemonsetRoleBinding, defaultServiceAccount)
+	r := &KubernetesImagePullerReconciler{
+		Client: c,
+		Scheme: scheme.Scheme,
+		Log:    ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+	}
+
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaultDeploymentName}, got); err != nil {
+		t.Fatalf("Error getting deployment: %v", err)
+	}
+
+	annotations := got.Spec.Template.Annotations
+	if annotations == nil {
+		t.Fatal("Expected pod template annotations to be set, got nil")
+	}
+	if _, ok := annotations["che.eclipse.org/configmap-hash"]; !ok {
+		t.Error("Expected che.eclipse.org/configmap-hash annotation on pod template")
+	}
+}
+
 func TestDeletesOldDeploymentOnNameChange(t *testing.T) {
 	type testcase struct {
 		name  string


### PR DESCRIPTION
## Summary
- Replaces direct pod deletion on ConfigMap content change with a pod template annotation (`che.eclipse.org/configmap-hash`) that triggers a proper rolling restart through the Deployment controller
- The annotation value is a deterministic hash of the desired ConfigMap data, making it idempotent — same content produces the same hash, no unnecessary rollouts
- The previous behaviour bypassed the Deployment's rollout strategy and killed all pods simultaneously, causing a full outage window

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/...` passes (all existing + new `TestAnnotationRolloutOnConfigMapChange`)
- [ ] Manual verification: change a ConfigMap value in the CR spec and confirm the Deployment triggers a rolling restart instead of deleting all pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration now triggers a rolling restart when the referenced ConfigMap content changes (even when the ConfigMap name stays the same).
  * Rollouts are driven by a deterministic ConfigMap hash stored on the Deployment pod template, improving consistency versus forced pod deletion.
* **Tests**
  * Added a unit test to verify the Deployment receives the `che.eclipse.org/configmap-hash` annotation after ConfigMap updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->