### PR TITLE
refactor: consolidate hardcoded defaults into pkg/defaults

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -18,6 +18,7 @@ import (
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/config"
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/rbac"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -71,15 +72,15 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	// Set defaults for any unset spec fields in a single update
 	needsUpdate := false
 	if instance.Spec.ConfigMapName == "" {
-		instance.Spec.ConfigMapName = "k8s-image-puller"
+		instance.Spec.ConfigMapName = defaults.ConfigMapName
 		needsUpdate = true
 	}
 	if instance.Spec.DeploymentName == "" {
-		instance.Spec.DeploymentName = "kubernetes-image-puller"
+		instance.Spec.DeploymentName = defaults.DeploymentName
 		needsUpdate = true
 	}
 	if instance.Spec.ImagePullerImage == "" {
-		instance.Spec.ImagePullerImage = "quay.io/eclipse/kubernetes-image-puller:next"
+		instance.Spec.ImagePullerImage = defaults.ImagePullerImage
 		needsUpdate = true
 	}
 	if needsUpdate {
@@ -92,7 +93,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Create the Role to allow the ServiceAccount to create Daemonsets
 	foundRole := &rbacv1.Role{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: "create-daemonset"}, foundRole)
+	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: defaults.RBACName}, foundRole)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating create-daemonset role")
 		if err = r.Create(ctx, rbac.NewRole(instance)); err != nil {
@@ -103,7 +104,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	foundRoleBinding := &rbacv1.RoleBinding{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: "create-daemonset"}, foundRoleBinding)
+	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: defaults.RBACName}, foundRoleBinding)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating create-daemonset RoleBinding")
 		if err = r.Create(ctx, rbac.NewRoleBinding(instance)); err != nil {
@@ -114,7 +115,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	foundServiceAccount := &corev1.ServiceAccount{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: "k8s-image-puller"}, foundServiceAccount)
+	err = r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: defaults.ServiceAccountName}, foundServiceAccount)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating k8s-image-puller ServiceAccount")
 		if err = r.Create(ctx, rbac.NewServiceAccount(instance)); err != nil {
@@ -155,7 +156,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 				// ConfigMap names are the same, delete pods and let the new pods pick up the new configmap
 
 				pods := &corev1.PodList{}
-				if err = r.List(ctx, pods, client.MatchingLabels{"app": "kubernetes-image-puller"}); err != nil {
+				if err = r.List(ctx, pods, client.MatchingLabels{"app": defaults.AppLabelValue}); err != nil {
 					log.Error(err, "Error listing pods")
 					return ctrl.Result{}, err
 				}
@@ -192,7 +193,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Find all configmaps owned by this imagepuller and delete ones that are not named ConfigMapName
 	configMaps := &corev1.ConfigMapList{}
-	if err = r.List(ctx, configMaps, client.MatchingLabels{"app": "kubernetes-image-puller"}); err != nil {
+	if err = r.List(ctx, configMaps, client.MatchingLabels{"app": defaults.AppLabelValue}); err != nil {
 		log.Error(err, "Could not list ConfigMaps")
 		return ctrl.Result{}, err
 	} else {
@@ -244,7 +245,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	deployments := &appsv1.DeploymentList{}
 	listOptions := &client.ListOptions{
 		Namespace:     instance.Namespace,
-		LabelSelector: labels.SelectorFromValidatedSet(map[string]string{"app": "kubernetes-image-puller"}),
+		LabelSelector: labels.SelectorFromValidatedSet(map[string]string{"app": defaults.AppLabelValue}),
 	}
 	err = r.List(ctx, deployments, listOptions)
 	if err != nil {
@@ -294,7 +295,7 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Dep
 	readOnlyRootFilesystem := true
 	var deploymentName string
 	if cr.Spec.DeploymentName == "" {
-		deploymentName = "kubernetes-image-puller"
+		deploymentName = defaults.DeploymentName
 	} else {
 		deploymentName = cr.Spec.DeploymentName
 	}
@@ -303,7 +304,7 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Dep
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
 			Name:      deploymentName,
-			Labels:    map[string]string{"app": "kubernetes-image-puller"},
+			Labels:    map[string]string{"app": defaults.AppLabelValue},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cr, chev1alpha1.SchemeBuilder.GroupVersion.WithKind("KubernetesImagePuller")),
 			},
@@ -311,14 +312,14 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Dep
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "kubernetes-image-puller"},
+				MatchLabels: map[string]string{"app": defaults.AppLabelValue},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "kubernetes-image-puller"},
+					Labels: map[string]string{"app": defaults.AppLabelValue},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "k8s-image-puller",
+					ServiceAccountName: defaults.ServiceAccountName,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
 						SeccompProfile: &corev1.SeccompProfile{
@@ -327,7 +328,7 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller) *appsv1.Dep
 					},
 					Containers: []corev1.Container{
 						{
-							Name:  "kubernetes-image-puller",
+							Name:  defaults.ContainerName,
 							Image: cr.Spec.ImagePullerImage,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &allowPrivilegeEscalation,

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/config"
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ var (
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "create-daemonset",
+			Name:            defaults.RBACName,
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 			ResourceVersion: "1",
@@ -68,19 +69,19 @@ var (
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "create-daemonset",
+			Name:            defaults.RBACName,
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 			ResourceVersion: "1",
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind: "ServiceAccount",
-			Name: "k8s-image-puller",
+			Name: defaults.ServiceAccountName,
 		}},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     "Role",
-			Name:     "create-daemonset",
+			Name:     defaults.RBACName,
 		},
 	}
 	defaultServiceAccount = &corev1.ServiceAccount{
@@ -89,15 +90,15 @@ var (
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "k8s-image-puller",
+			Name:            defaults.ServiceAccountName,
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 			ResourceVersion: "1",
 		},
 	}
-	defaultConfigMapName    = "k8s-image-puller"
-	defaultDeploymentName   = "kubernetes-image-puller"
-	defaultImagePullerImage = "quay.io/eclipse/kubernetes-image-puller:next"
+	defaultConfigMapName    = defaults.ConfigMapName
+	defaultDeploymentName   = defaults.DeploymentName
+	defaultImagePullerImage = defaults.ImagePullerImage
 )
 
 func defaultImagePuller() *chev1alpha1.KubernetesImagePuller {
@@ -333,7 +334,7 @@ func TestCreatesDeployment(t *testing.T) {
 		t.Errorf("Got error in reconcile: %v", err)
 	}
 
-	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: "kubernetes-image-puller"}, got); err != nil {
+	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaults.DeploymentName}, got); err != nil {
 		t.Errorf("Error getting deployment: %v", err)
 	}
 	if d := cmp.Diff(want, got); d != "" {
@@ -547,7 +548,7 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace:       namespace,
 					Name:            defaultConfigMapName,
 					ResourceVersion: "1",
-					Labels:          map[string]string{"app": "kubernetes-image-puller"},
+					Labels:          map[string]string{"app": defaults.AppLabelValue},
 					OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -596,7 +597,7 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace:       namespace,
 					Name:            defaultConfigMapName,
 					ResourceVersion: "1",
-					Labels:          map[string]string{"app": "kubernetes-image-puller"},
+					Labels:          map[string]string{"app": defaults.AppLabelValue},
 					OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -631,7 +632,7 @@ func TestCreatesConfigMap(t *testing.T) {
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
 					"IMAGES":                 "java11-maven=quay.io/eclipse/che-java11-maven:next;che-theia=quay.io/eclipse/che-theia:next;java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest",
-					"DAEMONSET_NAME":         "kubernetes-image-puller",
+					"DAEMONSET_NAME":         defaults.DeploymentName,
 					"NODE_SELECTOR":          "{}",
 					"IMAGE_PULL_SECRETS":     "",
 					"AFFINITY":               "{}",
@@ -643,7 +644,7 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace:       namespace,
 					Name:            "my-configmap",
 					ResourceVersion: "1",
-					Labels:          map[string]string{"app": "kubernetes-image-puller"},
+					Labels:          map[string]string{"app": defaults.AppLabelValue},
 					OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -716,7 +717,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 					Namespace:       namespace,
 					Name:            defaultConfigMapName,
 					ResourceVersion: "2",
-					Labels:          map[string]string{"app": "kubernetes-image-puller"},
+					Labels:          map[string]string{"app": defaults.AppLabelValue},
 					OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 				},
 				Data: map[string]string{
@@ -761,7 +762,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 					Namespace:       namespace,
 					Name:            "new-configmap",
 					ResourceVersion: "1",
-					Labels:          map[string]string{"app": "kubernetes-image-puller"},
+					Labels:          map[string]string{"app": defaults.AppLabelValue},
 					OwnerReferences: []metav1.OwnerReference{defaultCROwnerReference},
 				},
 				Data: map[string]string{
@@ -770,7 +771,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
-					"DAEMONSET_NAME":         "kubernetes-image-puller",
+					"DAEMONSET_NAME":         defaults.DeploymentName,
 					"IMAGES":                 "java11-maven=quay.io/eclipse/che-java11-maven:next;che-theia=quay.io/eclipse/che-theia:next;java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest",
 					"NODE_SELECTOR":          "{}",
 					"IMAGE_PULL_SECRETS":     "",
@@ -844,7 +845,7 @@ func TestDeletesOldDeploymentOnNameChange(t *testing.T) {
 				t.Errorf("Got error in reconcile: %v", err)
 			}
 			deployments := &appsv1.DeploymentList{}
-			c.List(context.TODO(), deployments, client.MatchingLabels{"app": "kubernetes-image-puller"})
+			c.List(context.TODO(), deployments, client.MatchingLabels{"app": defaults.AppLabelValue})
 			if err != nil {
 				t.Errorf("Error listing deployments: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 
 	orgv1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/controllers"
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -100,7 +101,7 @@ func main() {
 			"the manager will watch and manage resources in all Namespaces")
 	}
 
-	kubernetesImagePullerApp, err := labels.NewRequirement("app", selection.Equals, []string{"kubernetes-image-puller"})
+	kubernetesImagePullerApp, err := labels.NewRequirement("app", selection.Equals, []string{defaults.AppLabelValue})
 	if err != nil {
 		setupLog.Error(err, "failed to create label requirement")
 		os.Exit(1)

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,7 +31,7 @@ func NewImagePullerConfigMap(instance *chev1alpha1.KubernetesImagePuller) *corev
 }
 
 func DefaultImagePullerConfigMap(namespace string, name string) *corev1.ConfigMap {
-	configMapName := "k8s-image-puller"
+	configMapName := defaults.ConfigMapName
 	if name != "" {
 		configMapName = name
 	}
@@ -43,11 +44,11 @@ func DefaultImagePullerConfigMap(namespace string, name string) *corev1.ConfigMa
 			Name:      configMapName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app": "kubernetes-image-puller",
+				"app": defaults.AppLabelValue,
 			},
 		},
 		Data: map[string]string{
-			"DAEMONSET_NAME":         "kubernetes-image-puller",
+			"DAEMONSET_NAME":         defaults.DaemonSetName,
 			"IMAGES":                 "java11-maven=quay.io/eclipse/che-java11-maven:next;che-theia=quay.io/eclipse/che-theia:next;java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest",
 			"CACHING_INTERVAL_HOURS": "1",
 			"CACHING_MEMORY_REQUEST": "10Mi",
@@ -58,7 +59,7 @@ func DefaultImagePullerConfigMap(namespace string, name string) *corev1.ConfigMa
 			"IMAGE_PULL_SECRETS":     "",
 			"AFFINITY":               "{}",
 			"TOLERATIONS":            "[]",
-			"KIP_IMAGE":              "quay.io/eclipse/kubernetes-image-puller:next",
+			"KIP_IMAGE":              defaults.ImagePullerImage,
 			"NAMESPACE":              namespace,
 		},
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2012-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package defaults
+
+const (
+	ConfigMapName    = "k8s-image-puller"
+	DeploymentName   = "kubernetes-image-puller"
+	ImagePullerImage = "quay.io/eclipse/kubernetes-image-puller:next"
+
+	AppLabelValue      = "kubernetes-image-puller"
+	ContainerName      = "kubernetes-image-puller"
+	DaemonSetName      = "kubernetes-image-puller"
+	RBACName           = "create-daemonset"
+	ServiceAccountName = "k8s-image-puller"
+)

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -14,6 +14,7 @@ package rbac
 
 import (
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +27,7 @@ func NewRole(cr *chev1alpha1.KubernetesImagePuller) *rbacv1.Role {
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "create-daemonset",
+			Name:      defaults.RBACName,
 			Namespace: cr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cr, chev1alpha1.SchemeBuilder.GroupVersion.WithKind("KubernetesImagePuller")),
@@ -47,7 +48,7 @@ func NewRoleBinding(cr *chev1alpha1.KubernetesImagePuller) *rbacv1.RoleBinding {
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "create-daemonset",
+			Name:      defaults.RBACName,
 			Namespace: cr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cr, chev1alpha1.SchemeBuilder.GroupVersion.WithKind("KubernetesImagePuller")),
@@ -55,12 +56,12 @@ func NewRoleBinding(cr *chev1alpha1.KubernetesImagePuller) *rbacv1.RoleBinding {
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind: "ServiceAccount",
-			Name: "k8s-image-puller",
+			Name: defaults.ServiceAccountName,
 		}},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     "Role",
-			Name:     "create-daemonset",
+			Name:     defaults.RBACName,
 		},
 	}
 }
@@ -72,7 +73,7 @@ func NewServiceAccount(cr *chev1alpha1.KubernetesImagePuller) *corev1.ServiceAcc
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "k8s-image-puller",
+			Name:      defaults.ServiceAccountName,
 			Namespace: cr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cr, chev1alpha1.SchemeBuilder.GroupVersion.WithKind("KubernetesImagePuller")),


### PR DESCRIPTION
## Summary
- Creates new `pkg/defaults` package with constants for all default values (ConfigMap name, Deployment name, image, app label, RBAC name, ServiceAccount name)
- Updates controller, config, rbac, main, and test packages to use the shared constants instead of scattered string literals
- Reduces the risk of inconsistencies when default values need to change

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/...` passes (all existing tests)
- [x] Verified no remaining hardcoded default strings outside `pkg/defaults/` (only an informational log message in main.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)