### PR TITLE
fix: align CACHING_MEMORY_LIMIT default with Helm chart (20Mi)

### DIFF
--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -611,7 +611,7 @@ func TestCreatesConfigMap(t *testing.T) {
 			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"CACHING_INTERVAL_HOURS": "1",
-					"CACHING_MEMORY_LIMIT":   "30Mi",
+					"CACHING_MEMORY_LIMIT":   "20Mi",
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
@@ -660,7 +660,7 @@ func TestCreatesConfigMap(t *testing.T) {
 			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"CACHING_INTERVAL_HOURS": "1",
-					"CACHING_MEMORY_LIMIT":   "30Mi",
+					"CACHING_MEMORY_LIMIT":   "20Mi",
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
@@ -707,7 +707,7 @@ func TestCreatesConfigMap(t *testing.T) {
 			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"CACHING_INTERVAL_HOURS": "1",
-					"CACHING_MEMORY_LIMIT":   "30Mi",
+					"CACHING_MEMORY_LIMIT":   "20Mi",
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
@@ -802,7 +802,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 				},
 				Data: map[string]string{
 					"CACHING_INTERVAL_HOURS": "1",
-					"CACHING_MEMORY_LIMIT":   "30Mi",
+					"CACHING_MEMORY_LIMIT":   "20Mi",
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",
@@ -847,7 +847,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 				},
 				Data: map[string]string{
 					"CACHING_INTERVAL_HOURS": "1",
-					"CACHING_MEMORY_LIMIT":   "30Mi",
+					"CACHING_MEMORY_LIMIT":   "20Mi",
 					"CACHING_MEMORY_REQUEST": "10Mi",
 					"CACHING_CPU_LIMIT":      ".2",
 					"CACHING_CPU_REQUEST":    ".05",

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -51,7 +51,7 @@ func DefaultImagePullerConfigMap(namespace string, name string) *corev1.ConfigMa
 			"IMAGES":                 "java11-maven=quay.io/eclipse/che-java11-maven:next;che-theia=quay.io/eclipse/che-theia:next;java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest",
 			"CACHING_INTERVAL_HOURS": "1",
 			"CACHING_MEMORY_REQUEST": "10Mi",
-			"CACHING_MEMORY_LIMIT":   "30Mi",
+			"CACHING_MEMORY_LIMIT":   "20Mi",
 			"CACHING_CPU_REQUEST":    ".05",
 			"CACHING_CPU_LIMIT":      ".2",
 			"NODE_SELECTOR":          "{}",


### PR DESCRIPTION
## Summary
- Changes the operator's default `CACHING_MEMORY_LIMIT` from `30Mi` to `20Mi` to match the Helm chart default
- This inconsistency meant operator-managed and Helm-managed deployments behaved differently out of the box

Note: the Go app itself defaults to `5Mi` (in `cfg/envvars.go`), but both the Helm chart and operator override this via the ConfigMap. The Helm chart's `20Mi` is the published default users see.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/...` passes (updated test expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)