### PR TITLE
fix: increase scorecard wait-time to prevent CI timeouts

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,4 +53,4 @@ jobs:
         run: |
           make download-operator-sdk
           bin/operator-sdk olm install --version v0.28.0
-          bin/operator-sdk scorecard bundle
+          bin/operator-sdk scorecard bundle --wait-time 120s


### PR DESCRIPTION
## Summary
- Adds `--wait-time 120s` to the `operator-sdk scorecard bundle` invocation in CI
- The default 30s timeout is insufficient for 6 scorecard test pods to be scheduled and pull images on a fresh minikube cluster, causing intermittent `context deadline exceeded` failures

## Test plan
- [ ] Verify the scorecard CI job passes consistently after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)