### PR TITLE
chore: bump Go version from 1.22 to 1.26

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
-        go-version: '1.22'
+        go-version: '1.26'
     - name: Run unit tests
       run: make test
   image-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.22'
+          go-version: '1.26'
       - name: Release operator
         run: |
           RELEASE_VERSION=${{ github.event.inputs.version }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@
 
 # Build the manager binary
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 as builder
 ENV GOPATH=/go/
 ARG SKIP_TESTS="false"
 USER root

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/che-incubator/kubernetes-image-puller-operator
 
-go 1.22.0
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Summary
- Bumps Go from 1.22 (EOL) to 1.26 across go.mod, Dockerfile, and CI workflows
- Aligns with the kubernetes-image-puller repo which already uses Go 1.26
- Enables use of latest tooling (e.g. govulncheck) that requires newer Go versions

## Changes
- `go.mod`: 1.22.0 → 1.26.4
- `build/Dockerfile`: ubi9/go-toolset:1.22 → 1.26
- `.github/workflows/pr-check.yml`: go-version 1.22 → 1.26
- `.github/workflows/release.yml`: go-version 1.22 → 1.26

## Test plan
- [x] `go mod tidy` produces no changes
- [x] `make test` passes
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)