### PR TITLE
fix: stabilise flaky scorecard CI job

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -48,9 +48,18 @@ jobs:
         id: run-minikube
         uses: che-incubator/setup-minikube-action@fbf2aa1144e0088e9200fc2ecf5e26040ea2a8e4 # next
         with:
-          minikube-version: v1.34.0
-      - name: Run tests
+          minikube-version: v1.38.1
+      - name: Wait for cluster readiness
         run: |
-          make download-operator-sdk
-          bin/operator-sdk olm install --version v0.28.0
-          bin/operator-sdk scorecard bundle --wait-time 120s
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+          kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=120s
+      - name: Run tests
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            make download-operator-sdk
+            bin/operator-sdk olm install --version v0.28.0
+            bin/operator-sdk scorecard bundle --wait-time 120s


### PR DESCRIPTION
## Summary
- Bump minikube from v1.34.0 to v1.38.1 (16 months newer)
- Add `kubectl wait` for node and kube-system pod readiness before running tests
- Wrap scorecard step with `nick-fields/retry` (v4, SHA-pinned) for up to 3 attempts with 30s backoff

## Test plan
- [ ] Scorecard CI job passes on this PR
- [ ] Verify retry logic by checking job logs show single attempt on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test environment settings for better stability.
  * Added extra readiness checks before running validation steps, reducing flaky failures.
  * Made the validation process more resilient by retrying key setup and test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->