### PR TITLE
chore: add tolerations support, security context, and watch owned resources

### DIFF
--- a/bundle/manifests/che.eclipse.org_kubernetesimagepullers.yaml
+++ b/bundle/manifests/che.eclipse.org_kubernetesimagepullers.yaml
@@ -78,6 +78,8 @@ spec:
                 type: string
               nodeSelector:
                 type: string
+              tolerations:
+                type: string
             type: object
           status:
             description: KubernetesImagePullerStatus defines the observed state of

--- a/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-imagepuller-operator.clusterserviceversion.yaml
@@ -32,10 +32,10 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/kubernetes-image-puller-operator:1.1.0
-    createdAt: "2024-01-15T16:23:04Z"
+    createdAt: "2026-07-13T14:25:13Z"
     description: Create and manage kubernetes-image-puller instances.
-    operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/che-incubator/kubernetes-image-puller-operator
     support: Community
   name: kubernetes-imagepuller-operator.v1.1.0
@@ -86,6 +86,8 @@ spec:
             path: images
           - displayName: NodeSelector
             path: nodeSelector
+          - displayName: Tolerations
+            path: tolerations
         statusDescriptors:
           - description: KubernetesImagePuller image in use.
             displayName: Image
@@ -131,7 +133,9 @@ spec:
                 - create
           serviceAccountName: kubernetes-image-puller-operator-sa
       deployments:
-        - name: kubernetes-image-puller-operator-manager
+        - label:
+            name: kubernetes-image-puller-operator
+          name: kubernetes-image-puller-operator-manager
           spec:
             replicas: 1
             selector:
@@ -187,6 +191,15 @@ spec:
                       requests:
                         cpu: 100m
                         memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
                   - args:
                       - --secure-listen-address=0.0.0.0:8443
                       - --upstream=http://127.0.0.1:8080/
@@ -198,8 +211,15 @@ spec:
                       - containerPort: 8443
                         name: https
                     resources: {}
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 serviceAccountName: kubernetes-image-puller-operator-sa
                 terminationGracePeriodSeconds: 10
+                volumes:
+                  - emptyDir: {}
+                    name: tmp
       permissions:
         - rules:
             - apiGroups:

--- a/config/manifests/bases/kubernetes-image-puller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kubernetes-image-puller-operator.clusterserviceversion.yaml
@@ -59,6 +59,8 @@ spec:
         path: images
       - displayName: NodeSelector
         path: nodeSelector
+      - displayName: Tolerations
+        path: tolerations
       statusDescriptors:
       - description: KubernetesImagePuller image in use.
         displayName: Image

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,74 +16,74 @@ metadata:
   creationTimestamp: null
   name: role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - get
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - che.eclipse.org
-  resources:
-  - kubernetesimagepullers
-  - kubernetesimagepullers/status
-  - kubernetesimagepullers/finalizers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - che.eclipse.org
+    resources:
+      - kubernetesimagepullers
+      - kubernetesimagepullers/status
+      - kubernetesimagepullers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -382,7 +382,9 @@ func GetDeploymentConfigMapName(deployment *appsv1.Deployment) (string, error) {
 func (r *KubernetesImagePullerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&chev1alpha1.KubernetesImagePuller{}).
+		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Pod{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary
- Add `tolerations` field to the KubernetesImagePuller CRD spec and CSV spec descriptors
- Update controller to watch owned DaemonSet and Pod resources for better reconciliation
- Add security context (non-root, read-only root filesystem, drop all capabilities, seccomp) to the operator deployment
- Update operator-sdk version markers to v1.38.0 / go.kubebuilder.io/v4

## Test plan
- [ ] Verify the operator deploys successfully with the updated security context
- [ ] Verify tolerations can be set on a KubernetesImagePuller CR and are propagated
- [ ] Verify DaemonSet and Pod changes trigger reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring pod tolerations in `KubernetesImagePuller` resources.
  * Improved operator security with hardened container settings and a writable temporary workspace.
* **Improvements**
  * The operator now responds to changes in managed pods and daemon sets, improving reconciliation reliability.
* **Chores**
  * Updated operator metadata and clarified permission configuration without changing effective access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->