### PR TITLE
fix: Release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,14 @@ Then, to see these changes on OperatorHub:
 and [`community-operators-prod`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/) repositories.
 2. Copy a new bundle into the `community-operators` and `community-operators-prod` repositories:
 ```bash
-./make-release.sh <RELEASE_VERSION> --image-puller-image <IMAGE> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators-prod
-./make-release.sh <RELEASE_VERSION> --image-puller-image <IMAGE> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators
+./make-release.sh <RELEASE_VERSION> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators-prod
+./make-release.sh <RELEASE_VERSION> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators
 ```
-3. Copy `deploy/olm-catalog/kubernetes-imagepuller-operator/` to the `kubernetes-imagepuller-operator` folder of those repositories.
-4. Open two separate pull requests to [`community-operators`](https://github.com/k8s-operatorhub/community-operators/)
+3. Open two separate pull requests to [`community-operators`](https://github.com/k8s-operatorhub/community-operators/)
 and [`community-operators-prod`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/) repositories. 
 Examples of the PRs:
-- https://github.com/k8s-operatorhub/community-operators/pull/96
-- https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/87
+- https://github.com/k8s-operatorhub/community-operators/pull/8764
+- https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10447
 
 ### Trademark
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -46,10 +46,12 @@ init() {
     shift 1
   done
 
-  if [[ -z "${IMAGE_PULLER_IMAGE}" ]]; then
-    echo "[ERROR] --image-puller-image is required"
-    usage
-    exit 1
+  if [[ $RUN_RELEASE == "true" ]]; then
+    if [[ -z "${IMAGE_PULLER_IMAGE}" ]]; then
+      echo "[ERROR] --image-puller-image is required"
+      usage
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OperatorHub release instructions with revised `make-release.sh` commands to prepare updates for both production and community operator directories.
  * Removed the obsolete image puller argument from the release example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->