### PR TITLE
chore: Update release steps, fix using default KIP image

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,70 @@ $ kubectl apply -f config/samples/che_v1alpha1_kubernetesimagepuller.yaml -n kub
 
 A quirk of this project is that while the repository is named `kubernetes-image-puller-operator`, 
 the operator bundle on OperatorHub is named `kubernetes-imagepuller-operator`.  
-his was caused by the previous version of OLM deployment that required a Quay.io Application.  
+This was caused by the previous version of OLM deployment that required a Quay.io Application.
 
-Run `Release Kubernetes Image Puller operator` GitHub action to release a new bundle.
+##### Step 1: Run the Release GitHub Action
 
-Then, to see these changes on OperatorHub:
+Run the [`Release Kubernetes Image Puller operator`](https://github.com/che-incubator/kubernetes-image-puller-operator/actions/workflows/release.yml) GitHub Action with the following inputs:
+
+| Input | Description | Example                                         |
+|---|---|-------------------------------------------------|
+| `version` | Release version in `X.Y.Z` format | `1.1.2`                                         |
+| `imagePullerImage` | kubernetes-image-puller image to use | `quay.io/eclipse/kubernetes-image-puller:1.1.2` |
+| `forceRecreateTags` | Recreate existing tags (use with caution) | `false`                                         |
+
+##### Step 2: Checkout to the release branch
+
+After the GitHub Action completes, checkout to the release branch:
+
+```bash
+git fetch origin
+git checkout <RELEASE_VERSION>-release
+```
+
+##### Step 3: Test on Kubernetes and OpenShift
+
+Before publishing to OperatorHub, verify the release on both platforms.
+
+**Testing on Kubernetes (e.g. Minikube):**
+
+1. Install cert-manager (required for webhooks on Kubernetes):
+```bash
+kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+```
+2. Deploy the operator using the release catalog:
+```bash
+make deploy
+```
+3. Create a `KubernetesImagePuller` CR and verify:
+```bash
+kubectl apply -f config/samples/che_v1alpha1_kubernetesimagepuller.yaml -n kubernetes-image-puller-operator
+kubectl get pods -n kubernetes-image-puller-operator
+kubectl get daemonsets -A
+```
+4. Verify the image puller daemonset is running and pods are scheduled across nodes.
+5. Verify updating and deleting the CR works correctly.
+
+**Testing on OpenShift:**
+
+1. Deploy the operator:
+```bash
+make deploy
+```
+2. Create a `KubernetesImagePuller` CR and verify:
+```bash
+oc apply -f config/samples/che_v1alpha1_kubernetesimagepuller.yaml -n kubernetes-image-puller-operator
+oc get pods -n kubernetes-image-puller-operator
+oc get daemonsets -A
+```
+3. Verify the image puller daemonset is running and pods are scheduled across nodes.
+4. Verify updating and deleting the CR works correctly.
+
+##### Step 4: Publish to OperatorHub
+
 1. Fork and clone the [`community-operators`](https://github.com/k8s-operatorhub/community-operators) 
 and [`community-operators-prod`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/) repositories.
-2. Copy a new bundle into the `community-operators` and `community-operators-prod` repositories:
+2. Copy the new bundle into both repositories:
 ```bash
 ./make-release.sh <RELEASE_VERSION> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators-prod
 ./make-release.sh <RELEASE_VERSION> --prepare-community-operators-update --community-operators-repository-dir <PROJECT_DIR>/community-operators

--- a/api/v1alpha1/kubernetesimagepuller_types.go
+++ b/api/v1alpha1/kubernetesimagepuller_types.go
@@ -13,6 +13,7 @@
 package v1alpha1
 
 import (
+	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/defaults"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -81,6 +82,13 @@ type KubernetesImagePullerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []KubernetesImagePuller `json:"items"`
+}
+
+func (k *KubernetesImagePuller) GetImagePullerImage() string {
+	if k.Spec.ImagePullerImage != "" {
+		return k.Spec.ImagePullerImage
+	}
+	return defaults.ImagePullerImage
 }
 
 func addKnownTypes(s *runtime.Scheme) error {

--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -80,10 +80,15 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 		instance.Spec.DeploymentName = defaults.DeploymentName
 		needsUpdate = true
 	}
-	if instance.Spec.ImagePullerImage == "" {
-		instance.Spec.ImagePullerImage = defaults.ImagePullerImage
+
+	// Remove the default image from the spec.
+	// It allows you to use the image tied to the release.
+	if instance.Spec.ImagePullerImage == "quay.io/eclipse/kubernetes-image-puller:1.1.1" ||
+		instance.Spec.ImagePullerImage == "quay.io/eclipse/kubernetes-image-puller:next" {
+		instance.Spec.ImagePullerImage = ""
 		needsUpdate = true
 	}
+
 	if needsUpdate {
 		if err = r.Update(ctx, instance); err != nil {
 			log.Error(err, "Error updating KubernetesImagePuller")
@@ -268,8 +273,8 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// If ImagePullerImage from deployment is different than the spec, update deployment
-	if instance.Spec.ImagePullerImage != instance.Status.ImagePullerImage {
-		instance.Status.ImagePullerImage = instance.Spec.ImagePullerImage
+	if instance.Status.ImagePullerImage != instance.GetImagePullerImage() {
+		instance.Status.ImagePullerImage = instance.GetImagePullerImage()
 		err = r.Status().Update(ctx, instance)
 		if err != nil {
 			log.Error(err, "Error updating custom resource status")
@@ -323,7 +328,7 @@ func NewImagePullerDeployment(cr *chev1alpha1.KubernetesImagePuller, isOpenShift
 					Containers: []corev1.Container{
 						{
 							Name:            defaults.ContainerName,
-							Image:           cr.Spec.ImagePullerImage,
+							Image:           cr.GetImagePullerImage(),
 							SecurityContext: getContainerSecurityContext(isOpenShift),
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -35,6 +35,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	legacyImageV111 = "quay.io/eclipse/kubernetes-image-puller:1.1.1"
+	legacyImageNext = "quay.io/eclipse/kubernetes-image-puller:next"
+)
+
 // KubernetesImagePullerReconciler reconciles a KubernetesImagePuller object
 type KubernetesImagePullerReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
@@ -81,10 +86,7 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 		needsUpdate = true
 	}
 
-	// Remove the default image from the spec.
-	// It allows you to use the image tied to the release.
-	if instance.Spec.ImagePullerImage == "quay.io/eclipse/kubernetes-image-puller:1.1.1" ||
-		instance.Spec.ImagePullerImage == "quay.io/eclipse/kubernetes-image-puller:next" {
+	if instance.Spec.ImagePullerImage == legacyImageV111 || instance.Spec.ImagePullerImage == legacyImageNext {
 		instance.Spec.ImagePullerImage = ""
 		needsUpdate = true
 	}
@@ -273,8 +275,9 @@ func (r *KubernetesImagePullerReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// If ImagePullerImage from deployment is different than the spec, update deployment
-	if instance.Status.ImagePullerImage != instance.GetImagePullerImage() {
-		instance.Status.ImagePullerImage = instance.GetImagePullerImage()
+	effectiveImage := instance.GetImagePullerImage()
+	if instance.Status.ImagePullerImage != effectiveImage {
+		instance.Status.ImagePullerImage = effectiveImage
 		err = r.Status().Update(ctx, instance)
 		if err != nil {
 			log.Error(err, "Error updating custom resource status")

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -118,7 +118,7 @@ func defaultImagePullerWithAllDefaults() *chev1alpha1.KubernetesImagePuller {
 	}
 }
 
-func defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage() *chev1alpha1.KubernetesImagePuller {
+func defaultImagePullerWithConfigMapNameAndDeploymentName() *chev1alpha1.KubernetesImagePuller {
 	return &chev1alpha1.KubernetesImagePuller{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubernetesImagePuller",
@@ -186,6 +186,32 @@ func TestSetsAllDefaults(t *testing.T) {
 	}
 }
 
+func TestDeploymentUsesDefaultImageWhenSpecEmpty(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	client := setupClient(t, cr,
+		expectedConfigMap(cr),
+		createDaemonsetRole, createDaemonsetRoleBinding, defaultServiceAccount)
+	r := &KubernetesImagePullerReconciler{
+		Client: client,
+		Scheme: scheme.Scheme,
+		Log:    ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+	}
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Errorf("Got error in reconcile: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaultDeploymentName}, got); err != nil {
+		t.Errorf("Error getting deployment: %v", err)
+	}
+
+	if got.Spec.Template.Spec.Containers[0].Image != defaultImagePullerImage {
+		t.Errorf("Expected deployment image %q, got %q", defaultImagePullerImage, got.Spec.Template.Spec.Containers[0].Image)
+	}
+}
+
 func TestCreatesRole(t *testing.T) {
 	type testcase struct {
 		name string
@@ -196,7 +222,7 @@ func TestCreatesRole(t *testing.T) {
 
 	for _, tc := range []testcase{{
 		name: "default",
-		cr:   defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage(),
+		cr:   defaultImagePullerWithConfigMapNameAndDeploymentName(),
 		want: createDaemonsetRole,
 		got:  &rbacv1.Role{},
 	}} {
@@ -234,7 +260,7 @@ func TestCreatesRoleBinding(t *testing.T) {
 
 	for _, tc := range []testcase{{
 		name: "default",
-		cr:   defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage(),
+		cr:   defaultImagePullerWithConfigMapNameAndDeploymentName(),
 		want: createDaemonsetRoleBinding,
 		got:  &rbacv1.RoleBinding{},
 	}} {
@@ -272,7 +298,7 @@ func TestCreatesServiceAccount(t *testing.T) {
 
 	for _, tc := range []testcase{{
 		name: "default",
-		cr:   defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage(),
+		cr:   defaultImagePullerWithConfigMapNameAndDeploymentName(),
 		want: defaultServiceAccount,
 		got:  &corev1.ServiceAccount{},
 	}} {
@@ -301,11 +327,11 @@ func TestCreatesServiceAccount(t *testing.T) {
 }
 
 func TestCreatesDeployment(t *testing.T) {
-	client := setupClient(t, defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage(),
-		expectedConfigMap(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()),
+	client := setupClient(t, defaultImagePullerWithConfigMapNameAndDeploymentName(),
+		expectedConfigMap(defaultImagePullerWithConfigMapNameAndDeploymentName()),
 		createDaemonsetRole, createDaemonsetRoleBinding, defaultServiceAccount)
 	got := &appsv1.Deployment{}
-	want := expectedDeployment(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage())
+	want := expectedDeployment(defaultImagePullerWithConfigMapNameAndDeploymentName())
 	r := &KubernetesImagePullerReconciler{
 		Client: client,
 		Scheme: scheme.Scheme,
@@ -479,7 +505,7 @@ func TestCreatesConfigMap(t *testing.T) {
 
 	for _, tc := range []testcase{{
 		name: "default",
-		cr:   defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage(),
+		cr:   defaultImagePullerWithConfigMapNameAndDeploymentName(),
 		want: expectedConfigMap(defaultImagePuller()),
 		got:  &corev1.ConfigMap{},
 	},
@@ -664,7 +690,7 @@ func TestUpdatesConfigMap(t *testing.T) {
 					DeploymentName: defaultDeploymentName,
 				},
 			},
-			old: expectedConfigMap(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()),
+			old: expectedConfigMap(defaultImagePullerWithConfigMapNameAndDeploymentName()),
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:       namespace,

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -112,9 +112,8 @@ func defaultImagePullerWithAllDefaults() *chev1alpha1.KubernetesImagePuller {
 			ResourceVersion: "1",
 		},
 		Spec: chev1alpha1.KubernetesImagePullerSpec{
-			ConfigMapName:    defaultConfigMapName,
-			DeploymentName:   defaultDeploymentName,
-			ImagePullerImage: defaultImagePullerImage,
+			ConfigMapName:  defaultConfigMapName,
+			DeploymentName: defaultDeploymentName,
 		},
 	}
 }
@@ -131,9 +130,8 @@ func defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage() *che
 			ResourceVersion: "2",
 		},
 		Spec: chev1alpha1.KubernetesImagePullerSpec{
-			ConfigMapName:    defaultConfigMapName,
-			DeploymentName:   defaultDeploymentName,
-			ImagePullerImage: defaultImagePullerImage,
+			ConfigMapName:  defaultConfigMapName,
+			DeploymentName: defaultDeploymentName,
 		},
 	}
 }
@@ -389,9 +387,8 @@ func TestUpdatesImagePullerImageStatus(t *testing.T) {
 				ResourceVersion: "0",
 			},
 			Spec: chev1alpha1.KubernetesImagePullerSpec{
-				ConfigMapName:    defaultConfigMapName,
-				DeploymentName:   defaultDeploymentName,
-				ImagePullerImage: defaultImagePullerImage,
+				ConfigMapName:  defaultConfigMapName,
+				DeploymentName: defaultDeploymentName,
 			},
 		},
 		want: &chev1alpha1.KubernetesImagePuller{
@@ -401,9 +398,8 @@ func TestUpdatesImagePullerImageStatus(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Spec: chev1alpha1.KubernetesImagePullerSpec{
-				ConfigMapName:    defaultConfigMapName,
-				DeploymentName:   defaultDeploymentName,
-				ImagePullerImage: defaultImagePullerImage,
+				ConfigMapName:  defaultConfigMapName,
+				DeploymentName: defaultDeploymentName,
 			},
 			Status: chev1alpha1.KubernetesImagePullerStatus{
 				ImagePullerImage: defaultImagePullerImage,
@@ -499,10 +495,9 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: chev1alpha1.KubernetesImagePullerSpec{
-					DaemonsetName:    "other-daemonset-name",
-					ConfigMapName:    defaultConfigMapName,
-					DeploymentName:   defaultDeploymentName,
-					ImagePullerImage: defaultImagePullerImage,
+					DaemonsetName:  "other-daemonset-name",
+					ConfigMapName:  defaultConfigMapName,
+					DeploymentName: defaultDeploymentName,
 				},
 			},
 			want: &corev1.ConfigMap{
@@ -543,11 +538,10 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: chev1alpha1.KubernetesImagePullerSpec{
-					ConfigMapName:    defaultConfigMapName,
-					DeploymentName:   defaultDeploymentName,
-					DaemonsetName:    "other-daemonset-name",
-					ImagePullerImage: defaultImagePullerImage,
-					Images:           "che-devfile-registry=quay.io/eclipse/che-devfile-registry:latest,woopra-backend=quay.io/openshiftio/che-workspace-telemetry-woopra-backend:latest",
+					ConfigMapName:  defaultConfigMapName,
+					DeploymentName: defaultDeploymentName,
+					DaemonsetName:  "other-daemonset-name",
+					Images:         "che-devfile-registry=quay.io/eclipse/che-devfile-registry:latest,woopra-backend=quay.io/openshiftio/che-workspace-telemetry-woopra-backend:latest",
 				},
 			},
 			want: &corev1.ConfigMap{
@@ -588,9 +582,8 @@ func TestCreatesConfigMap(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: chev1alpha1.KubernetesImagePullerSpec{
-					ConfigMapName:    "my-configmap",
-					DeploymentName:   defaultDeploymentName,
-					ImagePullerImage: defaultImagePullerImage,
+					ConfigMapName:  "my-configmap",
+					DeploymentName: defaultDeploymentName,
 				},
 			},
 			want: &corev1.ConfigMap{
@@ -666,10 +659,9 @@ func TestUpdatesConfigMap(t *testing.T) {
 					Name:      "test-puller",
 				},
 				Spec: chev1alpha1.KubernetesImagePullerSpec{
-					DaemonsetName:    "new-daemonset",
-					ConfigMapName:    defaultConfigMapName,
-					DeploymentName:   defaultDeploymentName,
-					ImagePullerImage: defaultImagePullerImage,
+					DaemonsetName:  "new-daemonset",
+					ConfigMapName:  defaultConfigMapName,
+					DeploymentName: defaultDeploymentName,
 				},
 			},
 			old: expectedConfigMap(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()),
@@ -709,9 +701,8 @@ func TestUpdatesConfigMap(t *testing.T) {
 					// ResourceVersion: "0",
 				},
 				Spec: chev1alpha1.KubernetesImagePullerSpec{
-					ConfigMapName:    "new-configmap",
-					DeploymentName:   defaultDeploymentName,
-					ImagePullerImage: defaultImagePullerImage,
+					ConfigMapName:  "new-configmap",
+					DeploymentName: defaultDeploymentName,
 				},
 			},
 			want: &corev1.ConfigMap{

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -106,8 +106,7 @@ func mergeConfigMapWithCR(instance *chev1alpha1.KubernetesImagePuller, defaultCo
 	if instance.Spec.DaemonsetName != "" {
 		defaultConfigMap.Data["DAEMONSET_NAME"] = instance.Spec.DaemonsetName
 	}
-	if instance.Spec.ImagePullerImage != "" {
-		defaultConfigMap.Data["KIP_IMAGE"] = instance.Spec.ImagePullerImage
-	}
+
+	defaultConfigMap.Data["KIP_IMAGE"] = instance.GetImagePullerImage()
 	return defaultConfigMap
 }

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -108,5 +108,6 @@ func mergeConfigMapWithCR(instance *chev1alpha1.KubernetesImagePuller, defaultCo
 	}
 
 	defaultConfigMap.Data["KIP_IMAGE"] = instance.GetImagePullerImage()
+
 	return defaultConfigMap
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The operator now uses its built-in image automatically when no image is specified.
* **Bug Fixes**
  * Generated configuration and status now consistently reflect the effective image in use.
  * Legacy image values are handled more predictably by reverting to an empty spec and using the default image behavior.
* **Documentation**
  * Updated the OperatorHub release section with a detailed step-by-step workflow, testing guidance for both Kubernetes and OpenShift, and revised publishing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->