### PR TITLE
fix: use existing test helper for annotation rollout test

### DIFF
--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -787,9 +787,9 @@ func TestUpdatesConfigMap(t *testing.T) {
 }
 
 func TestAnnotationRolloutOnConfigMapChange(t *testing.T) {
-	cr := defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
 	cr.Spec.DaemonsetName = "new-daemonset"
-	oldConfigMap := expectedConfigMap(defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage())
+	oldConfigMap := expectedConfigMap(defaultImagePullerWithConfigMapNameAndDeploymentName())
 	deployment := NewImagePullerDeployment(cr, false)
 	deployment.ResourceVersion = "1"
 


### PR DESCRIPTION
## Summary

- Fix build failure on `main` caused by undefined function `defaultImagePullerWithConfigMapNameDeploymentNameAndImagePullerImage()` in `TestAnnotationRolloutOnConfigMapChange` (introduced in #202)
- Replace with existing `defaultImagePullerWithConfigMapNameAndDeploymentName()` which provides the same fields
- Setting `ImagePullerImage` to `defaults.ImagePullerImage` would not have worked anyway — the value matches `legacyImageNext`, causing the controller to clear it and return early before reaching the annotation logic under test

## Test plan

- [x] `go vet ./...` passes
- [x] `make test` passes — all tests green including `TestAnnotationRolloutOnConfigMapChange`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rollout behavior test coverage for ConfigMap changes.
  * Preserved validation that the expected pod template annotation is applied during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->