### PR TITLE
feat: emit Kubernetes Events on status condition transitions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,6 +84,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - che.eclipse.org
   resources:
   - kubernetesimagepullers

--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +55,7 @@ type KubernetesImagePullerReconciler struct {
 	Log         logr.Logger
 	Scheme      *runtime.Scheme
 	IsOpenShift bool
+	Recorder    events.EventRecorder
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -333,6 +335,29 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 	return ctrl.Result{}, nil
 }
 
+func (r *KubernetesImagePullerReconciler) setCondition(instance *chev1alpha1.KubernetesImagePuller, cond metav1.Condition) bool {
+	if !apimeta.SetStatusCondition(&instance.Status.Conditions, cond) {
+		return false
+	}
+	if r.Recorder == nil {
+		return true
+	}
+
+	eventType := corev1.EventTypeNormal
+	if (cond.Type == chev1alpha1.ConditionDegraded && cond.Status == metav1.ConditionTrue) ||
+		(cond.Type == chev1alpha1.ConditionReady && cond.Status == metav1.ConditionFalse) {
+		eventType = corev1.EventTypeWarning
+	}
+
+	msg := cond.Message
+	if msg == "" {
+		msg = "condition cleared"
+	}
+
+	r.Recorder.Eventf(instance, nil, eventType, cond.Reason, "ConditionChanged", "%s: %s", cond.Type, msg)
+	return true
+}
+
 func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, log logr.Logger, instance *chev1alpha1.KubernetesImagePuller, result ctrl.Result, reconcileErr error) error {
 	// Re-fetch the instance to get the latest version before updating status
 	latest := &chev1alpha1.KubernetesImagePuller{}
@@ -349,21 +374,21 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 	var changed bool
 
 	if reconcileErr != nil {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionDegraded,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: generation,
 			Reason:             "ReconcileError",
 			Message:            reconcileErr.Error(),
 		}) || changed
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
 			Reason:             "ReconcileError",
 			Message:            reconcileErr.Error(),
 		}) || changed
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionProgressing,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
@@ -378,21 +403,21 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 	}
 
 	if result != (ctrl.Result{}) {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionProgressing,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: generation,
 			Reason:             "Reconciling",
 			Message:            "Resource creation or update in progress",
 		}) || changed
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
 			Reason:             "Reconciling",
 			Message:            "Reconciliation in progress",
 		}) || changed
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionDegraded,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
@@ -415,7 +440,7 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 	}
 
 	if deploymentReady {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionReady,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: generation,
@@ -423,7 +448,7 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 			Message:            "All owned resources are available",
 		}) || changed
 	} else {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
@@ -433,14 +458,14 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 	}
 
 	if deploymentReady {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionProgressing,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: generation,
 			Reason:             "ReconcileComplete",
 		}) || changed
 	} else {
-		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+		changed = r.setCondition(latest, metav1.Condition{
 			Type:               chev1alpha1.ConditionProgressing,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: generation,
@@ -449,7 +474,7 @@ func (r *KubernetesImagePullerReconciler) updateConditions(ctx context.Context, 
 		}) || changed
 	}
 
-	changed = apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+	changed = r.setCondition(latest, metav1.Condition{
 		Type:               chev1alpha1.ConditionDegraded,
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: generation,

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -14,6 +14,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
@@ -27,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1177,5 +1180,280 @@ func TestSetsReadyFalseWhenDeploymentNotAvailable(t *testing.T) {
 		t.Error("Expected Degraded condition to be set")
 	} else if cond.Status != metav1.ConditionFalse {
 		t.Errorf("Expected Degraded=False when deployment not available, got %s", cond.Status)
+	}
+}
+
+// drainEvents collects all pending events from a FakeRecorder.
+func drainEvents(rec *events.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func hasEvent(events []string, eventType, reason string) bool {
+	prefix := eventType + " " + reason + " "
+	for _, e := range events {
+		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEmitsWarningEventsOnReconcileError(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	c := setupClient(t, cr)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	reconcileErr := fmt.Errorf("something went wrong")
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, reconcileErr); err != nil {
+		t.Fatalf("updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 3 {
+		t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+	}
+
+	if !hasEvent(events, string(corev1.EventTypeWarning), "ReconcileError") {
+		t.Errorf("Expected Warning ReconcileError event, got: %v", events)
+	}
+	if !hasEvent(events, string(corev1.EventTypeNormal), "ReconcileError") {
+		t.Errorf("Expected Normal ReconcileError event (Progressing=False), got: %v", events)
+	}
+}
+
+func TestEmitsEventsOnProgressing(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	c := setupClient(t, cr)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{Requeue: true}, nil); err != nil {
+		t.Fatalf("updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 3 {
+		t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+	}
+
+	wantEvents := []string{
+		"Normal Reconciling Progressing: Resource creation or update in progress",
+		"Warning Reconciling Ready: Reconciliation in progress",
+		"Normal Reconciling Degraded: condition cleared",
+	}
+	sort.Strings(events)
+	sort.Strings(wantEvents)
+	if diff := cmp.Diff(wantEvents, events); diff != "" {
+		t.Errorf("Events mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmitsEventsWhenDeploymentReady(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	deployment := expectedDeployment(cr)
+	deployment.Status.AvailableReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.Replicas = 1
+
+	c := setupClient(t, cr, deployment)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, nil); err != nil {
+		t.Fatalf("updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 3 {
+		t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+	}
+
+	wantEvents := []string{
+		"Normal AllResourcesReady Ready: All owned resources are available",
+		"Normal ReconcileComplete Progressing: condition cleared",
+		"Normal ReconcileComplete Degraded: condition cleared",
+	}
+	sort.Strings(events)
+	sort.Strings(wantEvents)
+	if diff := cmp.Diff(wantEvents, events); diff != "" {
+		t.Errorf("Events mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmitsEventsWhenDeploymentUnavailable(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	deployment := expectedDeployment(cr)
+	deployment.Status.AvailableReplicas = 0
+
+	c := setupClient(t, cr, deployment)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, nil); err != nil {
+		t.Fatalf("updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 3 {
+		t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+	}
+
+	wantEvents := []string{
+		"Warning DeploymentNotAvailable Ready: Deployment does not have available replicas",
+		"Normal DeploymentNotAvailable Progressing: Waiting for deployment to become available",
+		"Normal ReconcileComplete Degraded: condition cleared",
+	}
+	sort.Strings(events)
+	sort.Strings(wantEvents)
+	if diff := cmp.Diff(wantEvents, events); diff != "" {
+		t.Errorf("Events mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNoEventsWhenConditionsUnchanged(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	deployment := expectedDeployment(cr)
+	deployment.Status.AvailableReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.Replicas = 1
+
+	c := setupClient(t, cr, deployment)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	// First call sets conditions
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, nil); err != nil {
+		t.Fatalf("first updateConditions error: %v", err)
+	}
+	drainEvents(rec) // discard first-call events
+
+	// Second call with same state should produce no events
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, nil); err != nil {
+		t.Fatalf("second updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 0 {
+		t.Errorf("Expected 0 events on unchanged conditions, got %d: %v", len(events), events)
+	}
+}
+
+func TestEmitsEventsOnTransitionFromDegradedToReady(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	cr.Status.Conditions = []metav1.Condition{
+		{
+			Type:   chev1alpha1.ConditionDegraded,
+			Status: metav1.ConditionTrue,
+			Reason: "ReconcileError",
+		},
+		{
+			Type:   chev1alpha1.ConditionReady,
+			Status: metav1.ConditionFalse,
+			Reason: "ReconcileError",
+		},
+		{
+			Type:   chev1alpha1.ConditionProgressing,
+			Status: metav1.ConditionFalse,
+			Reason: "ReconcileError",
+		},
+	}
+
+	deployment := expectedDeployment(cr)
+	deployment.Status.AvailableReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.Replicas = 1
+
+	c := setupClient(t, cr, deployment)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{}, nil); err != nil {
+		t.Fatalf("updateConditions error: %v", err)
+	}
+
+	events := drainEvents(rec)
+
+	// Ready should transition False->True, Degraded True->False, Progressing reason changes
+	if !hasEvent(events, string(corev1.EventTypeNormal), "AllResourcesReady") {
+		t.Errorf("Expected Normal AllResourcesReady event, got: %v", events)
+	}
+	if !hasEvent(events, string(corev1.EventTypeNormal), "ReconcileComplete") {
+		t.Errorf("Expected Normal ReconcileComplete event, got: %v", events)
+	}
+}
+
+func TestReconcileEmitsEvents(t *testing.T) {
+	cr := defaultImagePullerWithConfigMapNameAndDeploymentName()
+	cr.Status.ImagePullerImage = defaultImagePullerImage
+
+	deployment := expectedDeployment(cr)
+	deployment.Status.AvailableReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.Replicas = 1
+
+	c := setupClient(t, cr, expectedConfigMap(cr), deployment,
+		createDaemonsetRole, createDaemonsetRoleBinding, defaultServiceAccount)
+	rec := events.NewFakeRecorder(10)
+	r := &KubernetesImagePullerReconciler{
+		Client:   c,
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("kubernetesimagepuller"),
+		Recorder: rec,
+	}
+
+	result, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Fatalf("Got error in reconcile: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("Expected no requeue but got requeue")
+	}
+
+	events := drainEvents(rec)
+	if len(events) == 0 {
+		t.Fatal("Expected events to be emitted through Reconcile, got none")
+	}
+
+	if !hasEvent(events, string(corev1.EventTypeNormal), "AllResourcesReady") {
+		t.Errorf("Expected Normal AllResourcesReady event through Reconcile, got: %v", events)
 	}
 }

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: kubernetes-image-puller-operator/kubernetes-image-puller-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: kubernetesimagepullers.che.eclipse.org
 spec:
   group: che.eclipse.org
@@ -21,7 +21,14 @@ spec:
     singular: kubernetesimagepuller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KubernetesImagePuller is the Schema for the kubernetesimagepullers
@@ -73,11 +80,72 @@ spec:
                 type: string
               nodeSelector:
                 type: string
+              tolerations:
+                type: string
             type: object
           status:
             description: KubernetesImagePullerStatus defines the observed state of
               KubernetesImagePuller
             properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               imagePullerImage:
                 description: KubernetesImagePuller image in use.
                 type: string
@@ -143,20 +211,33 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
-  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -165,49 +246,47 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
-  - deployments/finalizers
+  - daemonsets
   verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
+  - delete
   - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - che.eclipse.org
   resources:
-  - '*'
+  - kubernetesimagepullers
+  - kubernetesimagepullers/status
+  - kubernetesimagepullers/finalizers
   verbs:
   - create
   - delete

--- a/deploy/deployment/kubernetes/objects/kubernetes-image-puller-operator-role.Role.yaml
+++ b/deploy/deployment/kubernetes/objects/kubernetes-image-puller-operator-role.Role.yaml
@@ -9,20 +9,33 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
-  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -31,49 +44,47 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
-  - deployments/finalizers
+  - daemonsets
   verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
+  - delete
   - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - che.eclipse.org
   resources:
-  - '*'
+  - kubernetesimagepullers
+  - kubernetesimagepullers/status
+  - kubernetesimagepullers/finalizers
   verbs:
   - create
   - delete

--- a/deploy/deployment/kubernetes/objects/kubernetesimagepullers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/kubernetesimagepullers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: kubernetes-image-puller-operator/kubernetes-image-puller-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: kubernetesimagepullers.che.eclipse.org
 spec:
   group: che.eclipse.org
@@ -14,7 +14,14 @@ spec:
     singular: kubernetesimagepuller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KubernetesImagePuller is the Schema for the kubernetesimagepullers
@@ -66,11 +73,72 @@ spec:
                 type: string
               nodeSelector:
                 type: string
+              tolerations:
+                type: string
             type: object
           status:
             description: KubernetesImagePullerStatus defines the observed state of
               KubernetesImagePuller
             properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               imagePullerImage:
                 description: KubernetesImagePuller image in use.
                 type: string

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.21.0
     service.beta.openshift.io/inject-cabundle: "true"
   name: kubernetesimagepullers.che.eclipse.org
 spec:
@@ -21,7 +21,14 @@ spec:
     singular: kubernetesimagepuller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KubernetesImagePuller is the Schema for the kubernetesimagepullers
@@ -73,11 +80,72 @@ spec:
                 type: string
               nodeSelector:
                 type: string
+              tolerations:
+                type: string
             type: object
           status:
             description: KubernetesImagePullerStatus defines the observed state of
               KubernetesImagePuller
             properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               imagePullerImage:
                 description: KubernetesImagePuller image in use.
                 type: string
@@ -143,20 +211,33 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
-  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -165,49 +246,47 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
-  - deployments/finalizers
+  - daemonsets
   verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
+  - delete
   - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - che.eclipse.org
   resources:
-  - '*'
+  - kubernetesimagepullers
+  - kubernetesimagepullers/status
+  - kubernetesimagepullers/finalizers
   verbs:
   - create
   - delete

--- a/deploy/deployment/openshift/objects/kubernetes-image-puller-operator-role.Role.yaml
+++ b/deploy/deployment/openshift/objects/kubernetes-image-puller-operator-role.Role.yaml
@@ -9,20 +9,33 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
-  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -31,49 +44,47 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
-  - deployments/finalizers
+  - daemonsets
   verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
+  - delete
   - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - che.eclipse.org
   resources:
-  - '*'
+  - kubernetesimagepullers
+  - kubernetesimagepullers/status
+  - kubernetesimagepullers/finalizers
   verbs:
   - create
   - delete

--- a/deploy/deployment/openshift/objects/kubernetesimagepullers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/kubernetesimagepullers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.21.0
     service.beta.openshift.io/inject-cabundle: "true"
   name: kubernetesimagepullers.che.eclipse.org
 spec:
@@ -14,7 +14,14 @@ spec:
     singular: kubernetesimagepuller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KubernetesImagePuller is the Schema for the kubernetesimagepullers
@@ -66,11 +73,72 @@ spec:
                 type: string
               nodeSelector:
                 type: string
+              tolerations:
+                type: string
             type: object
           status:
             description: KubernetesImagePullerStatus defines the observed state of
               KubernetesImagePuller
             properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               imagePullerImage:
                 description: KubernetesImagePuller image in use.
                 type: string

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func main() {
 		Log:         ctrl.Log.WithName("controllers").WithName("KubernetesImagePuller"),
 		Scheme:      mgr.GetScheme(),
 		IsOpenShift: isOpenShift,
+		Recorder:    mgr.GetEventRecorder("KubernetesImagePuller"),
 	}
 
 	if err = imagePullerController.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
## Summary

- Adds an `events.EventRecorder` to the reconciler and emits Kubernetes Events whenever a status condition (Ready, Progressing, Degraded) transitions, giving operators a historical audit trail via `kubectl describe kubernetesimagepuller`
- Uses `Warning` events for negative transitions (Ready=False, Degraded=True) and `Normal` events for positive ones — events are only emitted when conditions actually change
- Adds RBAC permission for events (create/patch) and regenerates `deploy/deployment/` manifests

Closes #244

## Changes

| File | Change |
|------|--------|
| `controllers/kubernetesimagepuller_controller.go` | Add `Recorder` field, `setCondition` helper, replace 11 `SetStatusCondition` call sites |
| `controllers/kubernetesimagepuller_controller_test.go` | 7 new tests covering all event emission scenarios |
| `main.go` | Wire `mgr.GetEventRecorder()` into reconciler |
| `config/rbac/role.yaml` | Add events create/patch rule |
| `deploy/deployment/` | Regenerated via `make gen-deployment` |

## Test plan

- [x] `make test` — all existing + 7 new tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make gen-deployment` — deployment manifests regenerated
- [ ] Deploy operator, create CR, verify events appear in `kubectl describe kubernetesimagepuller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - KubernetesImagePuller now emits Kubernetes events for reconciliation progress, readiness, completion, and error states.
  - Custom resources now show `Ready` and `Age` columns for easier at-a-glance monitoring.
  - Custom resource status conditions have a more structured and validated format.
  - Added `spec.tolerations` support to the custom resource.

- **Improvements**
  - Refined operator RBAC rules to use narrower, least-privilege permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->