### PR TITLE
chore: bump try-in-web-ide action from v1.5.0 to v2.0.0

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@6d64b671fa7f83b770c5dd1d1094559a509d2a50 # v1.5.0
+        uses: redhat-actions/try-in-web-ide@5cd0cae0eb96c2fb1673268173a821e35931b825 # v2.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `redhat-actions/try-in-web-ide` from v1.5.0 to v2.0.0 (pinned by commit SHA)
- v2 modernises dependencies (TypeScript 6, ESLint 10, Jest 30) and fixes a high-severity brace-expansion DoS vulnerability ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg))
- Action inputs are backwards-compatible — no workflow changes needed

## Test plan

- [x] Verify action inputs unchanged between v1.5.0 and v2.0.0
- [ ] Confirm PR comment badge still appears on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the “Try in Web IDE” workflow to the latest supported action version.
  * Improved workflow reliability by pinning the action to a specific release commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->