### PR TITLE
fix: add delay to reconcile requeue to prevent hot-looping

### DIFF
--- a/controllers/kubernetesimagepuller_controller.go
+++ b/controllers/kubernetesimagepuller_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/config"
@@ -130,7 +131,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 			log.Error(err, "Error creating create-daemonset role")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	} else if err != nil {
 		return ctrl.Result{}, err
 	} else {
@@ -152,7 +153,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 			log.Error(err, "Error creating create-daemonset RoleBinding")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	} else if err != nil {
 		return ctrl.Result{}, err
 	} else {
@@ -163,7 +164,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 				log.Error(err, "Error deleting create-daemonset RoleBinding for roleRef update")
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		if !reflect.DeepEqual(foundRoleBinding.Subjects, desiredRoleBinding.Subjects) {
 			foundRoleBinding.Subjects = desiredRoleBinding.Subjects
@@ -182,7 +183,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 			log.Error(err, "Error creating k8s-image-puller ServiceAccount")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	// Create the configmap if it does not exist
@@ -195,7 +196,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	} else if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -246,7 +247,7 @@ func (r *KubernetesImagePullerReconciler) reconcile(ctx context.Context, log log
 	}
 
 	if configMapUpdated {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	// Clean up any old ConfigMaps owned by this instance that no longer match the desired name

--- a/controllers/kubernetesimagepuller_controller_test.go
+++ b/controllers/kubernetesimagepuller_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/che-incubator/kubernetes-image-puller-operator/pkg/config"
@@ -1246,7 +1247,7 @@ func TestEmitsEventsOnProgressing(t *testing.T) {
 		Recorder: rec,
 	}
 
-	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{Requeue: true}, nil); err != nil {
+	if err := r.updateConditions(context.TODO(), r.Log, cr, ctrl.Result{RequeueAfter: time.Second}, nil); err != nil {
 		t.Fatalf("updateConditions error: %v", err)
 	}
 


### PR DESCRIPTION
Replace immediate Requeue with RequeueAfter(1s) to rate-limit reconciliation loops when creating resources. This prevents the controller from spinning at maximum speed during resource creation, reducing API server load.

Also improve Makefile image tool detection with better command checking and a warning when neither docker nor podman is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes image puller reconciliation by using short, delayed retries after resource changes, helping prevent immediate repeated processing.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->